### PR TITLE
37 netcdf convertor for grib files

### DIFF
--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -51,8 +51,13 @@ class MarsCdsAdaptor(DirectMarsCdsAdaptor):
         data_format = request.pop("format", "grib")  # TODO: remove legacy syntax?
         data_format = request.pop("data_format", data_format)
 
+        if data_format in ["netcdf", "nc"]:
+            default_download_format = "zip"
+        else:
+            default_download_format = "as_source"
+
         # Format of download archive, as_source, zip, tar, list etc.
-        download_format = request.pop("download_format", "as_source")
+        download_format = request.pop("download_format", default_download_format)
 
         mapped_request = mapping.apply_mapping(request, self.mapping)  # type: ignore
 

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -51,7 +51,7 @@ class MarsCdsAdaptor(DirectMarsCdsAdaptor):
         data_format = request.pop("format", "grib")  # TODO: remove legacy syntax?
         data_format = request.pop("data_format", data_format)
 
-        if data_format in ["netcdf", "nc"]:
+        if data_format in ["netcdf", "nc", "netcdf_compressed"]:
             default_download_format = "zip"
         else:
             default_download_format = "as_source"
@@ -70,10 +70,17 @@ class MarsCdsAdaptor(DirectMarsCdsAdaptor):
         if output.returncode:
             raise RuntimeError("The MARS adaptor has crashed.")
 
-        if data_format in ["netcdf", "nc"]:
+        # NOTE: The NetCDF compressed option will not be visible on the WebPortal, it is here for testing
+        if data_format in ["netcdf", "nc", "netcdf_compressed"]:
+            if data_format in ["netcdf_compressed"]:
+                to_netcdf_kwargs = {
+                    "compression_options": "default",
+                }
+            else:
+                to_netcdf_kwargs = {}
             from cads_adaptors.tools.convertors import grib_to_netcdf_files
 
-            results = grib_to_netcdf_files(result)
+            results = grib_to_netcdf_files(result, **to_netcdf_kwargs)
         else:
             results = [result]
 

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -53,7 +53,7 @@ class MarsCdsAdaptor(DirectMarsCdsAdaptor):
         if data_format in ["netcdf", "nc"]:
             from cads_adaptors.tools.convertors import grib_to_netcdf_files
 
-            results = grib_to_netcdf_files(results)
+            results = grib_to_netcdf_files(result)
         else:
             results = [result]
 

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -40,21 +40,26 @@ class MarsCdsAdaptor(DirectMarsCdsAdaptor):
         from cads_adaptors.tools import download_tools
 
         # Format of data files, grib or netcdf
-        data_format = request.pop("format", "grib")
+        data_format = request.pop("format", "grib")  # TODO: remove legacy syntax?
+        data_format = request.pop("data_format", data_format)
 
         # Format of download archive, as_source, zip, tar, list etc.
         download_format = request.pop("download_format", "as_source")
 
         mapped_request = mapping.apply_mapping(request, self.mapping)  # type: ignore
-        if data_format not in ["grib"]:
-            # FIXME: reformat if needed
-            pass
 
         result = execute_mars(mapped_request)
+
+        if data_format in ["netcdf", "nc"]:
+            from cads_adaptors.tools.convertors import grib_to_netcdf_files
+
+            results = grib_to_netcdf_files(results)
+        else:
+            results = [result]
 
         download_kwargs = {
             "base_target": f"{self.collection_id}-{hash(tuple(request))}"
         }
         return download_tools.DOWNLOAD_FORMATS[download_format](
-            [result], **download_kwargs
+            results, **download_kwargs
         )

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -1,16 +1,37 @@
 import os
 
+DEFAULT_COMPRESSION_OPTIONS = {
+    "compression": "gzip",
+    "compression_opts": 9,
+    "shuffle": True,
+    "engine": "h5netcdf",
+}
 
-def grib_to_netcdf_files(grib_file):
+
+def grib_to_netcdf_files(grib_file, compression_options=None, **to_netcdf_kwargs):
     fname, extension = os.path.splitext(grib_file)
     import cfgrib
 
     datasets = cfgrib.open_datasets(grib_file)
 
+    if compression_options == "default":
+        compression_options = DEFAULT_COMPRESSION_OPTIONS
+
+    if compression_options is not None:
+        to_netcdf_kwargs.setdefault(
+            "engine", compression_options.pop("engine", "h5netcdf")
+        )
+
     out_nc_files = []
     for i, dataset in enumerate(datasets):
+        if compression_options is not None:
+            to_netcdf_kwargs.update(
+                {
+                    "encoding": {var: compression_options for var in dataset},
+                }
+            )
         out_fname = f"{fname}_{i}.nc"
-        dataset.to_netcdf(out_fname)
+        dataset.to_netcdf(out_fname, **to_netcdf_kwargs)
         out_nc_files.append(out_fname)
 
     return out_nc_files

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -1,0 +1,16 @@
+import os
+
+def grib_to_netcdf_files(grib_file):
+    fname, extension = os.path.splitext(grib_file)
+    import cfgrib
+
+    datasets = cfgrib.open_datasets(grib_file)
+    
+    out_nc_files = []
+    for i, dataset  in enumerate(datasets):
+        out_fname = f"{fname}_{i}.nc"
+        dataset.to_netcdf(out_fname)
+        out_nc_files.append(out_fname)
+    
+    return out_nc_files
+

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -1,16 +1,16 @@
 import os
 
+
 def grib_to_netcdf_files(grib_file):
     fname, extension = os.path.splitext(grib_file)
     import cfgrib
 
     datasets = cfgrib.open_datasets(grib_file)
-    
+
     out_nc_files = []
-    for i, dataset  in enumerate(datasets):
+    for i, dataset in enumerate(datasets):
         out_fname = f"{fname}_{i}.nc"
         dataset.to_netcdf(out_fname)
         out_nc_files.append(out_fname)
-    
-    return out_nc_files
 
+    return out_nc_files

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
 - pandas
 - python-dateutil
 - cfgrib
+- h5netcdf
 - pip:
   - ecmwflibs
   - cfgrib

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,8 @@ dependencies:
 - pandas
 - python-dateutil
 - pip:
+  - ecmwflibs
+  - cfgrib
   - rooki
   - cacholote
   - multiurl

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,5 @@ dependencies:
 - cfgrib
 - h5netcdf
 - pip:
-  - ecmwflibs
-  - cfgrib
   - rooki
   - multiurl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
   "Topic :: Scientific/Engineering"
 ]
 dependencies = [
+  "ecmwflibs",
+  "cfgrib",
   "cacholote",
   "multiurl",
   "rooki",

--- a/tests/test_30_convertors.py
+++ b/tests/test_30_convertors.py
@@ -1,24 +1,28 @@
-from cads_adaptors.tools import convertors
 import os
-import requests
 import tempfile
 
-TEST_GRIB_FILE ="https://get.ecmwf.int/repository/test-data/cfgrib/era5-levels-members.grib"
+import requests
 
+from cads_adaptors.tools import convertors
+
+TEST_GRIB_FILE = (
+    "https://get.ecmwf.int/repository/test-data/cfgrib/era5-levels-members.grib"
+)
 
 
 def test_grib_to_netcdf():
     grib_file = requests.get(TEST_GRIB_FILE)
     with tempfile.TemporaryDirectory() as tmpdirname:
-        tmp_grib_file = os.path.join(tmpdirname, 'test.grib')
-        with open(tmp_grib_file, 'wb') as f:
+        tmp_grib_file = os.path.join(tmpdirname, "test.grib")
+        with open(tmp_grib_file, "wb") as f:
             f.write(grib_file.content)
-        
+
         netcdf_files = convertors.grib_to_netcdf_files(tmp_grib_file)
         assert isinstance(netcdf_files, list)
-        assert len(netcdf_files)==1
-        
-        netcdf_files = convertors.grib_to_netcdf_files(tmp_grib_file, compression_options='default')
-        assert isinstance(netcdf_files, list)
-        assert len(netcdf_files)==1
+        assert len(netcdf_files) == 1
 
+        netcdf_files = convertors.grib_to_netcdf_files(
+            tmp_grib_file, compression_options="default"
+        )
+        assert isinstance(netcdf_files, list)
+        assert len(netcdf_files) == 1

--- a/tests/test_30_convertors.py
+++ b/tests/test_30_convertors.py
@@ -1,0 +1,24 @@
+from cads_adaptors.tools import convertors
+import os
+import requests
+import tempfile
+
+TEST_GRIB_FILE ="https://get.ecmwf.int/repository/test-data/cfgrib/era5-levels-members.grib"
+
+
+
+def test_grib_to_netcdf():
+    grib_file = requests.get(TEST_GRIB_FILE)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_grib_file = os.path.join(tmpdirname, 'test.grib')
+        with open(tmp_grib_file, 'wb') as f:
+            f.write(grib_file.content)
+        
+        netcdf_files = convertors.grib_to_netcdf_files(tmp_grib_file)
+        assert isinstance(netcdf_files, list)
+        assert len(netcdf_files)==1
+        
+        netcdf_files = convertors.grib_to_netcdf_files(tmp_grib_file, compression_options='default')
+        assert isinstance(netcdf_files, list)
+        assert len(netcdf_files)==1
+


### PR DESCRIPTION
A basic netCDF convertor based on cfgrib, using cfgrib.open_datasets as suggested by Ale.

I have tested with several datasets, including the more complex CARRA (Arctic on Lambert projection) and it seems to be working well. It produces several netCDF files when it is unable to make a single datacube.

We need to do some very thorough testing, but this will allow us to do that, and we will put an "Experimental" caveat on the web-portal if/where needed.