### PR TITLE
Raise when mars return no data

### DIFF
--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -45,6 +45,8 @@ class DirectMarsCdsAdaptor(cds.AbstractCdsAdaptor):
 
         if output.returncode:
             raise RuntimeError("The Direct MARS adaptor has crashed.")
+        if not os.path.getsize(result):
+            raise RuntimeError("The Direct MARS adaptor returned no data.")
 
         return open(result)  # type: ignore
 
@@ -75,6 +77,8 @@ class MarsCdsAdaptor(DirectMarsCdsAdaptor):
 
         if output.returncode:
             raise RuntimeError("The MARS adaptor has crashed.")
+        if not os.path.getsize(result):
+            raise RuntimeError("The MARS adaptor returned no data.")
 
         # NOTE: The NetCDF compressed option will not be visible on the WebPortal, it is here for testing
         if data_format in ["netcdf", "nc", "netcdf_compressed"]:


### PR DESCRIPTION
Looks like MARS does not always crash when bad requests are submitted, sometimes it returns empty files.
For example:
```python
collection_id="reanalysis-era5-pressure-levels"

request = {
    "product_type": "foo",  # <- 
    "format": "grib",
    "variable": "temperature",
    "pressure_level": "1",
    "year": "1971",
    "month": "01",
    "day": "01",
    "time": "06:00",
}
```