### PR TITLE
Include receipts in downloads and refactor of common code

### DIFF
--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -32,7 +32,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
     def make_receipt(
         self,
         request: Request,
-        download_size: [None, int] = None,
+        download_size: Any = None,
         filenames: list = [],
         **kwargs
     ) -> dict[str, Any]:
@@ -42,6 +42,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         **kwargs contains any other fields that are calculated during the runtime of the adaptor
         """
         from datetime import datetime as dt
+
         # Update kwargs with default values
         if download_size is None:
             download_size = "unknown"

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -34,7 +34,9 @@ class AbstractCdsAdaptor(AbstractAdaptor):
     def get_licences(self, request: Request) -> list[tuple[str, int]]:
         return self.licences
 
-    def retrieve(self, request: Request) -> Any:
+    # This is a second __init__, but only for when we have a request at hand
+    # and currently only implemented for retrieve methods
+    def __init_retrieve__(self, request: Request):
         self.input_request = deepcopy(request)
         self.receipt = request.pop("receipt", True)
 
@@ -50,7 +52,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
 
         paths = ensure_list(paths)
         filenames = [os.path.basename(path) for path in paths]
-        kwargs.setdefault("base_target", f"{self.collection_id}-{hash(tuple(paths))}")
+        kwargs.setdefault("base_target", f"{self.collection_id}-{hash(tuple(self.input_request))}")
 
         if receipt:
             if receipt_kwargs is None:

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -22,7 +22,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         self.input_request: Request = Request()
         self.mapped_request: Request = Request()
         self.download_format: str = "zip"
-        self.receipt: bool = True
+        self.receipt: bool = False
 
     def validate(self, request: Request) -> bool:
         return True

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -57,6 +57,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
 
         paths = ensure_list(paths)
         filenames = [os.path.basename(path) for path in paths]
+        # TODO: use request-id instead of hash
         kwargs.setdefault("base_target", f"{self.collection_id}-{hash(tuple(self.input_request))}")
 
         # Allow adaptor possibility of over-riding request value
@@ -105,7 +106,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
             "licence": [f"{licence[0]} (version {licence[1]})" for licence in self.licences],
 
             # TODO: Add request-id information to the context
-            # "request-id": self.config.get("process_id", "Unavailable"),
+            "request-uid": self.config.get("request_uid", "Unavailable"),
             #
             # TODO: Add URL/DNS information to the context for populating these fields:
             # "web-portal": self.???, # Need update to information available to adaptors

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -39,7 +39,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
 
     # This is essentially a second __init__, but only for when we have a request at hand
     # and currently only implemented for retrieve methods
-    def _pre_retrieve_(self, request: Request, default_download_format="zip"):
+    def _pre_retrieve(self, request: Request, default_download_format="zip"):
         self.input_request = deepcopy(request)
         self.receipt = request.pop("receipt", True)
         self.download_format = request.pop("download_format", default_download_format)

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -100,6 +100,10 @@ class AbstractCdsAdaptor(AbstractAdaptor):
             # TODO: Change to URLs for licence instead of slug
             "licence": [f"{licence[0]} (version {licence[1]})" for licence in self.licences],
 
+            # TODO: Get static URLs:
+            # "user-support": "https://link/to/user/support"
+            # "privacy-policy": "https://link/to/privacy/policy"
+
             # TODO: Add request-id information to the context
             # "request-id": self.config.get("process_id", "Unavailable"),
             #
@@ -107,8 +111,6 @@ class AbstractCdsAdaptor(AbstractAdaptor):
             # "web-portal": self.???, # Need update to information available to adaptors
             # "api-access": "https://url-to-data-api/{self.collection_id}"
             # "metadata-api-access": "https://url-to-metadata-api/{self.collection_id}"
-            # "user-support": "https://link/to/user/support"
-            # "privacy-policy": "https://link/to/privacy/policy"
             #
             # TODO: Add metadata information to config, this could also be done via the metadata api
             # "citation": self.???, # Need update to information available to adaptors

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -48,8 +48,6 @@ class AbstractCdsAdaptor(AbstractAdaptor):
     def make_download_object(
         self,
         paths: Union[str, list],
-        receipt: bool = True,
-        receipt_kwargs: Union[dict, None] = None,
         **kwargs,
     ):
         from cads_adaptors.tools import download_tools
@@ -61,9 +59,9 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         filenames = [os.path.basename(path) for path in paths]
         kwargs.setdefault("base_target", f"{self.collection_id}-{hash(tuple(self.input_request))}")
 
-        if receipt:
-            if receipt_kwargs is None:
-                receipt_kwargs = {}
+        # Allow adaptor possibility of over-riding request value
+        if kwargs.get("receipt", self.receipt):
+            receipt_kwargs = kwargs.pop("receipt_kwargs", {})
             kwargs.setdefault(
                 "receipt", self.make_receipt(filenames=filenames, **receipt_kwargs)
             )

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -97,12 +97,12 @@ class AbstractCdsAdaptor(AbstractAdaptor):
             "download-size": download_size,
             "filenames": filenames,
 
+            # Get static URLs:
+            "user-support": "https://support.ecmwf.int",
+            "privacy-policy": "https://cds.climate.copernicus.eu/disclaimer-privacy",
+
             # TODO: Change to URLs for licence instead of slug
             "licence": [f"{licence[0]} (version {licence[1]})" for licence in self.licences],
-
-            # TODO: Get static URLs:
-            # "user-support": "https://link/to/user/support"
-            # "privacy-policy": "https://link/to/privacy/policy"
 
             # TODO: Add request-id information to the context
             # "request-id": self.config.get("process_id", "Unavailable"),

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -96,18 +96,22 @@ class AbstractCdsAdaptor(AbstractAdaptor):
             "request-timestamp": dt.now().strftime("%Y-%m-%d %H:%M:%S"),
             "download-size": download_size,
             "filenames": filenames,
-            "licence": self.licences,
-            # TODO: fetch relevant information from metadata, potentially via API or populated directly
-            # The following does not work:
-            "request-id": self.config.get("process_id", "Unavailable"),
-            #   in the config opbject.
+
+            # TODO: Change to URLs for licence instead of slug
+            "licence": [f"{licence[0]} (version {licence[1]})" for licence in self.licences],
+
+            # TODO: Add request-id information to the context
+            # "request-id": self.config.get("process_id", "Unavailable"),
+            #
+            # TODO: Add URL/DNS information to the context for populating these fields:
             # "web-portal": self.???, # Need update to information available to adaptors
-            # "request-id": self.???, # Need update to information available to adaptors
-            # "citation": self.???, # Need update to information available to adaptors
             # "api-access": "https://url-to-data-api/{self.collection_id}"
             # "metadata-api-access": "https://url-to-metadata-api/{self.collection_id}"
             # "user-support": "https://link/to/user/support"
             # "privacy-policy": "https://link/to/privacy/policy"
+            #
+            # TODO: Add metadata information to config, this could also be done via the metadata api
+            # "citation": self.???, # Need update to information available to adaptors
             **kwargs,
             **self.config.get("additional_receipt_info", {}),
         }

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -28,3 +28,43 @@ class AbstractCdsAdaptor(AbstractAdaptor):
 
     def get_licences(self, request: Request) -> list[tuple[str, int]]:
         return self.licences
+
+    def make_receipt(
+        self,
+        request: Request,
+        download_size: [None, int] = None,
+        filenames: list = [],
+        **kwargs
+    ) -> dict[str, Any]:
+        """
+        Create a receipt to be included in the downloaded archive.
+
+        **kwargs contains any other fields that are calculated during the runtime of the adaptor
+        """
+        from datetime import datetime as dt
+        # Update kwargs with default values
+        if download_size is None:
+            download_size = "unknown"
+
+        receipt = {
+            "collection-id": self.collection_id,
+            "request": request,
+            "request-timestamp": dt.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "request-id": self.config.get("process_id"),
+            "download-size": download_size,
+            "filenames": filenames,
+            "licence": self.licences,
+            # TODO: fetch relevant information from metadata, potentially via API or populated directly
+            #   in the config opbject.
+            # "web-portal": self.???, # Need update to information available to adaptors
+            # "request-id": self.???, # Need update to information available to adaptors
+            # "citation": self.???, # Need update to information available to adaptors
+            # "api-access": "https://url-to-data-api/{self.collection_id}"
+            # "metadata-api-access": "https://url-to-metadata-api/{self.collection_id}"
+            # "user-support": "https://link/to/user/support"
+            # "privacy-policy": "https://link/to/privacy/policy"
+            **kwargs,
+            **self.config.get("additional_receipt_info", {}),
+        }
+
+        return receipt

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -18,8 +18,10 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         self.licences: list[tuple[str, int]] = config.pop("licences", [])
         self.config = config
         self.context = Context()
+        # The following attributes are updated during the retireve method
         self.input_request: Request = Request()
         self.mapped_request: Request = Request()
+        self.download_format: str = "zip"
         self.receipt: bool = True
 
     def validate(self, request: Request) -> bool:

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -58,7 +58,9 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         paths = ensure_list(paths)
         filenames = [os.path.basename(path) for path in paths]
         # TODO: use request-id instead of hash
-        kwargs.setdefault("base_target", f"{self.collection_id}-{hash(tuple(self.input_request))}")
+        kwargs.setdefault(
+            "base_target", f"{self.collection_id}-{hash(tuple(self.input_request))}"
+        )
 
         # Allow adaptor possibility of over-riding request value
         if kwargs.get("receipt", self.receipt):
@@ -97,14 +99,13 @@ class AbstractCdsAdaptor(AbstractAdaptor):
             "request-timestamp": dt.now().strftime("%Y-%m-%d %H:%M:%S"),
             "download-size": download_size,
             "filenames": filenames,
-
             # Get static URLs:
             "user-support": "https://support.ecmwf.int",
             "privacy-policy": "https://cds.climate.copernicus.eu/disclaimer-privacy",
-
             # TODO: Change to URLs for licence instead of slug
-            "licence": [f"{licence[0]} (version {licence[1]})" for licence in self.licences],
-
+            "licence": [
+                f"{licence[0]} (version {licence[1]})" for licence in self.licences
+            ],
             # TODO: Add request-id information to the context
             "request-uid": self.config.get("request_uid", "Unavailable"),
             #

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -58,8 +58,9 @@ class DirectMarsCdsAdaptor(cds.AbstractCdsAdaptor):
         return open(result)  # type: ignore
 
 
-class MarsCdsAdaptor(DirectMarsCdsAdaptor):
+class MarsCdsAdaptor(cds.AbstractCdsAdaptor):
     def retrieve(self, request: Request) -> BinaryIO:
+        super().__init_retrieve__(request=request)
         from cads_adaptors.tools import download_tools
 
         # Format of data files, grib or netcdf
@@ -95,6 +96,4 @@ class MarsCdsAdaptor(DirectMarsCdsAdaptor):
         download_kwargs = {
             "base_target": f"{self.collection_id}-{hash(tuple(request))}"
         }
-        return download_tools.DOWNLOAD_FORMATS[download_format](
-            results, **download_kwargs
-        )
+        return self.make_download_object(results)

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -6,6 +6,24 @@ from cads_adaptors.adaptors import Context, Request, cds
 from cads_adaptors.tools.general import ensure_list
 
 
+def convert_format(result, data_format):
+    # NOTE: The NetCDF compressed option will not be visible on the WebPortal, it is here for testing
+    if data_format in ["netcdf", "nc", "netcdf_compressed"]:
+        if data_format in ["netcdf_compressed"]:
+            to_netcdf_kwargs = {
+                "compression_options": "default",
+            }
+        else:
+            to_netcdf_kwargs = {}
+        from cads_adaptors.tools.convertors import grib_to_netcdf_files
+
+        paths = grib_to_netcdf_files(result, **to_netcdf_kwargs)
+    else:
+        paths = [result]
+    
+    return paths
+
+
 def execute_mars(
     request: Union[Request, list],
     target: str = "data.grib",
@@ -78,18 +96,7 @@ class MarsCdsAdaptor(cds.AbstractCdsAdaptor):
 
         result = execute_mars(self.mapped_request, context=self.context)
 
-        # NOTE: The NetCDF compressed option will not be visible on the WebPortal, it is here for testing
-        if data_format in ["netcdf", "nc", "netcdf_compressed"]:
-            if data_format in ["netcdf_compressed"]:
-                to_netcdf_kwargs = {
-                    "compression_options": "default",
-                }
-            else:
-                to_netcdf_kwargs = {}
-            from cads_adaptors.tools.convertors import grib_to_netcdf_files
-
-            paths = grib_to_netcdf_files(result, **to_netcdf_kwargs)
-        else:
-            paths = [result]
+        paths = convert_format(result, data_format)
 
         return self.make_download_object(paths)
+

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -27,9 +27,10 @@ def convert_format(
     elif data_format in ["grib", "grib2", "grb", "grb2"]:
         paths = [result]
     else:
-        context.stdout = (
-            context.user_visible_log
-        ) = "WARNING: Unrecoginsed data_format requested, returning as original grib/grib2 format"
+        if context is not None:
+            context.stdout = (
+                context.user_visible_log
+            ) = "WARNING: Unrecoginsed data_format requested, returning as original grib/grib2 format"
         paths = [result]
 
     return paths

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -84,11 +84,8 @@ class MarsCdsAdaptor(cds.AbstractCdsAdaptor):
 
         data_format = request.pop("data_format", "grib")
 
-        #  For now, zip is default download format for everything, options in place to change later
-        # if data_format in ["netcdf", "nc", "netcdf_compressed"]:
-        #     default_download_format = "zip"
-        # else:
-        #     default_download_format = "as_source"
+        # To preserve existing ERA5 functionality the default download_format="as_source"
+        request.setdefault("download_format", "as_source")
 
         self._pre_retrieve_(request=request)
 

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -1,7 +1,6 @@
 import os
 from typing import BinaryIO, Union
 
-from cads_adaptors import mapping
 from cads_adaptors.adaptors import Context, Request, cds
 from cads_adaptors.tools.general import ensure_list
 
@@ -20,7 +19,7 @@ def convert_format(result, data_format):
         paths = grib_to_netcdf_files(result, **to_netcdf_kwargs)
     else:
         paths = [result]
-    
+
     return paths
 
 
@@ -78,8 +77,7 @@ class DirectMarsCdsAdaptor(cds.AbstractCdsAdaptor):
 
 class MarsCdsAdaptor(cds.AbstractCdsAdaptor):
     def retrieve(self, request: Request) -> BinaryIO:
-
-         # TODO: Remove legacy syntax all together
+        # TODO: Remove legacy syntax all together
         if "format" in request:
             _data_format = request.pop("format")
             request.setdefault("data_format", _data_format)
@@ -99,4 +97,3 @@ class MarsCdsAdaptor(cds.AbstractCdsAdaptor):
         paths = convert_format(result, data_format)
 
         return self.make_download_object(paths)
-

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -102,7 +102,7 @@ class MarsCdsAdaptor(cds.AbstractCdsAdaptor):
         # To preserve existing ERA5 functionality the default download_format="as_source"
         request.setdefault("download_format", "as_source")
 
-        self._pre_retrieve_(request=request)
+        self._pre_retrieve(request=request)
 
         result = execute_mars(self.mapped_request, context=self.context)
 

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -1,4 +1,5 @@
 import typing as T
+from copy import deepcopy
 
 from cads_adaptors import AbstractCdsAdaptor, mapping
 from cads_adaptors.adaptors import Request
@@ -38,9 +39,11 @@ class MultiAdaptor(AbstractCdsAdaptor):
         return this_request
 
     def retrieve(self, request: Request):
-        from cads_adaptors.tools import adaptor_tools, download_tools
+        from cads_adaptors.tools import adaptor_tools
 
-        download_format = request.pop("download_format", "zip")
+        self.input_request = deepcopy(request)
+        self.receipt = request.pop("receipt", True)
+        self.download_format = request.pop("download_format", "zip")
 
         these_requests = {}
         exception_logs: T.Dict[str, str] = {}
@@ -57,7 +60,8 @@ class MultiAdaptor(AbstractCdsAdaptor):
             # TODO: check this_request is valid for this_adaptor, or rely on try?
             #  i.e. split_request does NOT implement constraints.
             if len(this_request) > 0:
-                this_request.setdefault("download_format", "list")
+                this_request["download_format"] = "list"
+                this_request["receipt"] = False
                 these_requests[this_adaptor] = this_request
 
         results = []
@@ -79,33 +83,29 @@ class MultiAdaptor(AbstractCdsAdaptor):
         # get the paths
         paths = [res.name for res in results]
 
-        download_kwargs = dict(
-            base_target=f"{self.collection_id}-{hash(tuple(results))}"
-        )
-
-        return download_tools.DOWNLOAD_FORMATS[download_format](
-            paths, **download_kwargs
+        return self.make_download_object(
+            paths,
         )
 
 
 class MultiMarsCdsAdaptor(MultiAdaptor):
     def retrieve(self, request: Request):
         """For MultiMarsCdsAdaptor we just want to apply mapping from each adaptor."""
-        from cads_adaptors.adaptors.mars import execute_mars
+        from cads_adaptors.adaptors.mars import execute_mars, convert_format
         from cads_adaptors.tools import adaptor_tools, download_tools
 
-        download_format = request.pop("download_format", "as_source")
+        self.input_request = deepcopy(request)
+        self.receipt = request.pop("receipt", True)
+        self.download_format = request.pop("download_format", "zip")
 
         # Format of data files, grib or netcdf
-        request.pop("format", "grib")
+        data_format = request.pop("format", "grib")
 
         mapped_requests = []
         logger.debug(f"MultiMarsCdsAdaptor, full_request: {request}")
         for adaptor_tag, adaptor_desc in self.config["adaptors"].items():
             this_adaptor = adaptor_tools.get_adaptor(adaptor_desc, self.form)
             this_values = adaptor_desc.get("values", {})
-
-            # logger.debug(f"MultiMarsCdsAdaptor, {adaptor_tag}, config: {this_adaptor.config}")
 
             this_request = self.split_request(
                 request, this_values, **this_adaptor.config
@@ -122,12 +122,6 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
         logger.debug(f"MultiMarsCdsAdaptor, mapped_requests: {mapped_requests}")
         result = execute_mars(mapped_requests, context=self.context)
 
-        # TODO: Handle alternate data_format
+        paths = convert_format(result, data_format)
 
-        download_kwargs = {
-            "base_target": f"{self.collection_id}-{hash(tuple(request))}"
-        }
-
-        return download_tools.DOWNLOAD_FORMATS[download_format](
-            [result], **download_kwargs
-        )
+        return self.make_download_object(paths)

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -42,7 +42,7 @@ class MultiAdaptor(AbstractCdsAdaptor):
         from cads_adaptors.tools import adaptor_tools
 
         self.input_request = deepcopy(request)
-        self.receipt = request.pop("receipt", True)
+        self.receipt = request.pop("receipt", False)
         self.download_format = request.pop("download_format", "zip")
 
         these_requests = {}
@@ -95,7 +95,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
         from cads_adaptors.tools import adaptor_tools
 
         self.input_request = deepcopy(request)
-        self.receipt = request.pop("receipt", True)
+        self.receipt = request.pop("receipt", False)
         self.download_format = request.pop("download_format", "zip")
 
         # Format of data files, grib or netcdf

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -91,8 +91,8 @@ class MultiAdaptor(AbstractCdsAdaptor):
 class MultiMarsCdsAdaptor(MultiAdaptor):
     def retrieve(self, request: Request):
         """For MultiMarsCdsAdaptor we just want to apply mapping from each adaptor."""
-        from cads_adaptors.adaptors.mars import execute_mars, convert_format
-        from cads_adaptors.tools import adaptor_tools, download_tools
+        from cads_adaptors.adaptors.mars import convert_format, execute_mars
+        from cads_adaptors.tools import adaptor_tools
 
         self.input_request = deepcopy(request)
         self.receipt = request.pop("receipt", True)

--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -5,7 +5,7 @@ from cads_adaptors.adaptors import Request, cds
 
 class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
     def retrieve(self, request: Request) -> BinaryIO:
-         # TODO: Remove legacy syntax all together
+        # TODO: Remove legacy syntax all together
         if "format" in request:
             _download_format = request.pop("format")
             request.setdefault("download_format", _download_format)

--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import BinaryIO
 
 from cads_adaptors import mapping
@@ -7,10 +6,9 @@ from cads_adaptors.adaptors import Request, cds
 
 class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
     def retrieve(self, request: Request) -> BinaryIO:
-        from cads_adaptors.tools import download_tools, url_tools
+        super().retrieve(request=request)
 
-        receipt = request.pop("receipt", True)
-        full_request = deepcopy(request)
+        from cads_adaptors.tools import url_tools
 
         download_format = request.pop("format", "zip")  # TODO: Remove legacy syntax
         # CADS syntax over-rules legacy syntax
@@ -31,12 +29,4 @@ class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
         urls = [ru["url"] for ru in requests_urls]
         paths = url_tools.try_download(urls)
 
-        download_kwargs = {"base_target": f"{self.collection_id}-{hash(tuple(urls))}"}
-
-        if receipt:
-            download_kwargs.update(
-                {"receipt": self.make_receipt(full_request, filenames=paths)}
-            )
-        return download_tools.DOWNLOAD_FORMATS[download_format](
-            paths, **download_kwargs
-        )
+        return self.make_download_object(paths)

--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -6,7 +6,7 @@ from cads_adaptors.adaptors import Request, cds
 
 class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
     def retrieve(self, request: Request) -> BinaryIO:
-        super().retrieve(request=request)
+        super().__init_retrieve__(request=request)
 
         from cads_adaptors.tools import url_tools
 

--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -8,6 +8,8 @@ class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
     def retrieve(self, request: Request) -> BinaryIO:
         from cads_adaptors.tools import download_tools, url_tools
 
+        receipt = request.pop("receipt", True)
+
         download_format = request.pop("format", "zip")  # TODO: Remove legacy syntax
         # CADS syntax over-rules legacy syntax
         download_format = request.pop("download_format", download_format)
@@ -27,8 +29,14 @@ class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
         urls = [ru["url"] for ru in requests_urls]
         paths = url_tools.try_download(urls)
 
-        download_kwargs = {"base_target": f"{self.collection_id}-{hash(tuple(urls))}"}
+        download_kwargs = {
+            "base_target": f"{self.collection_id}-{hash(tuple(urls))}"
+        }
 
+        if receipt:
+            download_kwargs.update({
+                "receipt": self.make_receipt(request, filenames=paths)
+            })
         return download_tools.DOWNLOAD_FORMATS[download_format](
             paths, **download_kwargs
         )

--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import BinaryIO
 
 from cads_adaptors import mapping
@@ -9,6 +10,7 @@ class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
         from cads_adaptors.tools import download_tools, url_tools
 
         receipt = request.pop("receipt", True)
+        full_request = deepcopy(request)
 
         download_format = request.pop("format", "zip")  # TODO: Remove legacy syntax
         # CADS syntax over-rules legacy syntax
@@ -29,14 +31,12 @@ class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
         urls = [ru["url"] for ru in requests_urls]
         paths = url_tools.try_download(urls)
 
-        download_kwargs = {
-            "base_target": f"{self.collection_id}-{hash(tuple(urls))}"
-        }
+        download_kwargs = {"base_target": f"{self.collection_id}-{hash(tuple(urls))}"}
 
         if receipt:
-            download_kwargs.update({
-                "receipt": self.make_receipt(request, filenames=paths)
-            })
+            download_kwargs.update(
+                {"receipt": self.make_receipt(full_request, filenames=paths)}
+            )
         return download_tools.DOWNLOAD_FORMATS[download_format](
             paths, **download_kwargs
         )

--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -1,28 +1,22 @@
 from typing import BinaryIO
 
-from cads_adaptors import mapping
 from cads_adaptors.adaptors import Request, cds
 
 
 class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
     def retrieve(self, request: Request) -> BinaryIO:
-        super().__init_retrieve__(request=request)
+         # TODO: Remove legacy syntax all together
+        if "format" in request:
+            _download_format = request.pop("format")
+            request.setdefault("download_format", _download_format)
+
+        self._pre_retrieve_(request=request)
 
         from cads_adaptors.tools import url_tools
 
-        download_format = request.pop("format", "zip")  # TODO: Remove legacy syntax
-        # CADS syntax over-rules legacy syntax
-        download_format = request.pop("download_format", download_format)
-
-        # Do not need to check twice
-        # if download_format not in {"zip", "tgz"}:
-        #     raise ValueError(f"{download_format} is not supported")
-
-        mapped_request = mapping.apply_mapping(request, self.mapping)  # type: ignore
-
         # Convert request to list of URLs
         requests_urls = url_tools.requests_to_urls(
-            mapped_request, patterns=self.config["patterns"]
+            self.mapped_request, patterns=self.config["patterns"]
         )
 
         # try to download URLs

--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -10,7 +10,7 @@ class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
             _download_format = request.pop("format")
             request.setdefault("download_format", _download_format)
 
-        self._pre_retrieve_(request=request)
+        self._pre_retrieve(request=request)
 
         from cads_adaptors.tools import url_tools
 

--- a/cads_adaptors/tools/download_tools.py
+++ b/cads_adaptors/tools/download_tools.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, BinaryIO, Callable, Dict, List
+from typing import Any, BinaryIO, Callable, Dict, List, Union
 
 import yaml
 
@@ -67,7 +67,7 @@ def targz_paths(
 def list_paths(
     paths: List[str],
     **kwargs,
-) -> List:
+) -> List[BinaryIO]:
     if kwargs.get("receipt") is not None:
         receipt_fname = f"receipt-{kwargs.get('base_target', 'nohash')}.yaml"
         with open(receipt_fname, "w") as receipt_file:
@@ -76,10 +76,12 @@ def list_paths(
     return [open(path, "rb") for path in ensure_list(paths)]
 
 
-def as_source(paths: List[str], **kwargs) -> BinaryIO:
+def as_source(paths: List[str], **kwargs) -> Union[BinaryIO, List[BinaryIO]]:
     # Only return as_source if a single path, otherwise list MUST be requested
-    assert len(paths) == 1
-    return open(paths[0], "rb")
+    if len(paths) == 1:
+        return open(paths[0], "rb")
+    else:
+        return list_paths(paths, **kwargs)
 
 
 DOWNLOAD_FORMATS: Dict[str, Callable] = {

--- a/cads_adaptors/tools/download_tools.py
+++ b/cads_adaptors/tools/download_tools.py
@@ -22,9 +22,10 @@ def zip_paths(
             archive.write(path, archive_name)
 
         if receipt is not None:
+            yaml_output: str = yaml.safe_dump(receipt, indent=2)
             archive.writestr(
                 f"receipt-{base_target}.yaml",
-                data=yaml.safe_dump(receipt, ensure_ascii=False, indent=2),
+                data=yaml_output,
             )
 
     for path in paths:
@@ -37,6 +38,7 @@ def zip_paths(
 def targz_paths(
     paths: List[str],
     base_target: str = "output-data",
+    receipt: Any = None,
     **kwargs,
 ) -> BinaryIO:
     import tarfile
@@ -50,6 +52,12 @@ def targz_paths(
                 archive_name = os.path.basename(path)
             archive.add(path, arcname=archive_name)
 
+        if receipt is not None:
+            receipt_fname = f"receipt-{base_target}.yaml"
+            with open(receipt_fname, "w") as receipt_file:
+                yaml.safe_dump(receipt, stream=receipt_file, indent=2)
+            archive.add(receipt_fname)
+
     for path in paths:
         os.remove(path)
 
@@ -60,6 +68,11 @@ def list_paths(
     paths: List[str],
     **kwargs,
 ) -> List:
+    if kwargs.get("receipt") is not None:
+        receipt_fname = f"receipt-{kwargs.get('base_target', hash(paths))}.yaml"
+        with open(receipt_fname, "w") as receipt_file:
+            yaml.safe_dump(kwargs.get("receipt"), stream=receipt_file, indent=2)
+        paths.append(receipt_fname)
     return [open(path, "rb") for path in ensure_list(paths)]
 
 

--- a/cads_adaptors/tools/download_tools.py
+++ b/cads_adaptors/tools/download_tools.py
@@ -1,11 +1,15 @@
 import os
-from typing import BinaryIO, Callable, Dict, List
+from typing import Any, BinaryIO, Callable, Dict, List
+
+import yaml
 
 from cads_adaptors.tools.general import ensure_list
 
 
 # TODO zipstream for archive creation
-def zip_paths(paths: List[str], base_target: str = "output-data", **kwargs) -> BinaryIO:
+def zip_paths(
+    paths: List[str], base_target: str = "output-data", receipt: Any = None, **kwargs
+) -> BinaryIO:
     import zipfile
 
     target = f"{base_target}.zip"
@@ -16,6 +20,12 @@ def zip_paths(paths: List[str], base_target: str = "output-data", **kwargs) -> B
             else:
                 archive_name = os.path.basename(path)
             archive.write(path, archive_name)
+
+        if receipt is not None:
+            archive.writestr(
+                f"receipt-{base_target}.yaml",
+                data=yaml.safe_dump(receipt, ensure_ascii=False, indent=2),
+            )
 
     for path in paths:
         os.remove(path)

--- a/cads_adaptors/tools/download_tools.py
+++ b/cads_adaptors/tools/download_tools.py
@@ -69,7 +69,7 @@ def list_paths(
     **kwargs,
 ) -> List:
     if kwargs.get("receipt") is not None:
-        receipt_fname = f"receipt-{kwargs.get('base_target', hash(paths))}.yaml"
+        receipt_fname = f"receipt-{kwargs.get('base_target', 'nohash')}.yaml"
         with open(receipt_fname, "w") as receipt_file:
             yaml.safe_dump(kwargs.get("receipt"), stream=receipt_file, indent=2)
         paths.append(receipt_fname)


### PR DESCRIPTION
This started out to close #59 , but evolved to include a general refactor to reduce duplicated code, i.e.:
- several adaptors call a common  `_pre_retrieve` method that performs general pre-processing
- a `make_download_object` method which handles the receipts and archiving
- the convert_format method is implemented more generally