### PR TITLE
test invalid parameters

### DIFF
--- a/tests/test_10_constraints.py
+++ b/tests/test_10_constraints.py
@@ -85,7 +85,11 @@ def test_apply_constraints() -> None:
 
 
 @pytest.mark.parametrize(
-    "selections", ({"foo": {"500"}}, {"foo": {"500"}, "level": {"500"}})
+    "selections",
+    (
+        {"foo": {"500"}},
+        {"foo": {"500"}, "level": {"500"}},
+    ),
 )
 def test_apply_constraints_errors(selections: dict[str, set[Any]]) -> None:
     form = {"level": {"500", "850"}, "param": {"Z", "T"}, "number": {"1"}}

--- a/tests/test_10_constraints.py
+++ b/tests/test_10_constraints.py
@@ -85,7 +85,7 @@ def test_apply_constraints() -> None:
 
 
 @pytest.mark.parametrize(
-    "selections", ({"foo": {"500"}}, {"foo": {"500"}, "bar": {"500"}})
+    "selections", ({"foo": {"500"}}, {"foo": {"500"}, "level": {"500"}})
 )
 def test_apply_constraints_errors(selections) -> None:
     form = {"level": {"500", "850"}, "param": {"Z", "T"}, "number": {"1"}}

--- a/tests/test_10_constraints.py
+++ b/tests/test_10_constraints.py
@@ -87,7 +87,7 @@ def test_apply_constraints() -> None:
 @pytest.mark.parametrize(
     "selections", ({"foo": {"500"}}, {"foo": {"500"}, "level": {"500"}})
 )
-def test_apply_constraints_errors(selections) -> None:
+def test_apply_constraints_errors(selections: dict[str, set[Any]]) -> None:
     form = {"level": {"500", "850"}, "param": {"Z", "T"}, "number": {"1"}}
 
     raw_constraints = [

--- a/tests/test_10_constraints.py
+++ b/tests/test_10_constraints.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import pytest
+
 from cads_adaptors import constraints
 
 
@@ -80,6 +82,20 @@ def test_apply_constraints() -> None:
     assert constraints.apply_constraints(form, {"level": {"500"}}, raw_constraints)[
         "number"
     ] == ["1"]
+
+
+@pytest.mark.parametrize(
+    "selections", ({"foo": {"500"}}, {"foo": {"500"}, "bar": {"500"}})
+)
+def test_apply_constraints_errors(selections) -> None:
+    form = {"level": {"500", "850"}, "param": {"Z", "T"}, "number": {"1"}}
+
+    raw_constraints = [
+        {"level": {"500"}, "param": {"Z"}},
+        {"level": {"850"}, "param": {"T"}},
+    ]
+    with pytest.raises(constraints.ParameterError, match="invalid param 'foo'"):
+        constraints.apply_constraints(form, selections, raw_constraints)
 
 
 def test_parse_constraints() -> None:


### PR DESCRIPTION
Hi there,

PR https://github.com/ecmwf-projects/cads-adaptors/pull/72 introduced a breaking change.
You can reproduce the error with [this integration test](https://github.com/ecmwf-projects/cads-api-client/blob/01ece063b41ce12995a4771e499e09a5d00f4174/tests/integration_test_20_processing.py#L95-L100).

I think there are 2 separate problems, which is why the test covers 2 scenarios:
1. When there is a single selection and this is invalid, the algorithm implicitly fails and raises a `KeyError` rather than a `ParameterError`
2. When there are multiple selections and one of them is invalid, the algorithm does not raise a `ParameterError`

In summary, #72 does not implement [this line](https://github.com/ecmwf-projects/cads-adaptors/blob/9fb29b98e6c19abd8380289164a132aceb2426fa/cads_adaptors/constraints.py#L185) and the `ParameterError` catched by `cads-processing-api-service` [here](https://github.com/ecmwf-projects/cads-processing-api-service/blob/23787fb92c818cdf75045f4818bf9117518c55f7/cads_processing_api_service/constraints.py#L26) is never raised.

I thought I would open a PR with tests to reproduce the behaviour before #72 so you can easily decide if/how to revise the algorithm recently introduced.
