### PR TITLE
Implement default estimate_costing function

### DIFF
--- a/cads_adaptors/adaptors/__init__.py
+++ b/cads_adaptors/adaptors/__init__.py
@@ -73,7 +73,7 @@ class DummyAdaptor(AbstractAdaptor):
     def apply_constraints(self, request: Request) -> dict[str, Any]:
         return {}
 
-    def estimate_costing(self, request: Request) -> dict[str, int]:
+    def estimate_costs(self, request: Request) -> dict[str, int]:
         size = int(request.get("size", 0))
         time = int(request.get("time", 0.0))
         return {"size": size, "time": time}

--- a/cads_adaptors/adaptors/__init__.py
+++ b/cads_adaptors/adaptors/__init__.py
@@ -54,7 +54,7 @@ class AbstractAdaptor(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def estimate_costing(self, request: Request) -> dict[str, int]:
+    def estimate_costs(self, request: Request) -> dict[str, int]:
         pass
 
     @abc.abstractmethod

--- a/cads_adaptors/adaptors/__init__.py
+++ b/cads_adaptors/adaptors/__init__.py
@@ -28,7 +28,7 @@ class AbstractAdaptor(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def estimate_costs(self, request: Request) -> dict[str, int]:
+    def estimate_costing(self, request: Request) -> dict[str, int]:
         pass
 
     @abc.abstractmethod
@@ -47,7 +47,7 @@ class DummyAdaptor(AbstractAdaptor):
     def apply_constraints(self, request: Request) -> dict[str, Any]:
         return {}
 
-    def estimate_costs(self, request: Request) -> dict[str, int]:
+    def estimate_costing(self, request: Request) -> dict[str, int]:
         size = int(request.get("size", 0))
         time = int(request.get("time", 0.0))
         return {"size": size, "time": time}

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -35,7 +35,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
     def apply_constraints(self, request: Request) -> dict[str, Any]:
         return constraints.validate_constraints(self.form, request, self.constraints)
 
-    def estimate_costing(self, request: Request) -> dict[str, int]:
+    def estimate_costs(self, request: Request) -> dict[str, int]:
         cost = {
             "number_of_values": costing.estimate_number_of_values(self.form, request)
         }

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -31,7 +31,9 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         return constraints.validate_constraints(self.form, request, self.constraints)
 
     def estimate_costs(self, request: Request) -> dict[str, int]:
-        costs = {"size": costing.estimate_size(self.form, request, self.constraints)}
+        costs = {
+            "number_of_fields": costing.estimate_number_of_fields(self.form, request)
+        }
         return costs
 
     def get_licences(self, request: Request) -> list[tuple[str, int]]:

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -32,7 +32,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
 
     def estimate_costing(self, request: Request) -> dict[str, int]:
         cost = {
-            "number_of_fields": costing.estimate_number_of_fields(self.form, request)
+            "number_of_values": costing.estimate_number_of_values(self.form, request)
         }
         return cost
 

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -37,7 +37,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
 
     def estimate_costs(self, request: Request) -> dict[str, int]:
         cost = {
-            "number_of_values": costing.estimate_number_of_values(self.form, request)
+            "number_of_fields": costing.estimate_number_of_fields(self.form, request)
         }
         return cost
 

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -30,11 +30,11 @@ class AbstractCdsAdaptor(AbstractAdaptor):
     def apply_constraints(self, request: Request) -> dict[str, Any]:
         return constraints.validate_constraints(self.form, request, self.constraints)
 
-    def estimate_costs(self, request: Request) -> dict[str, int]:
-        costs = {
+    def estimate_costing(self, request: Request) -> dict[str, int]:
+        cost = {
             "number_of_fields": costing.estimate_number_of_fields(self.form, request)
         }
-        return costs
+        return cost
 
     def get_licences(self, request: Request) -> list[tuple[str, int]]:
         return self.licences

--- a/cads_adaptors/costing.py
+++ b/cads_adaptors/costing.py
@@ -74,7 +74,10 @@ def estimate_size(
     return estimate_granules(form, selection, _constraints, safe=safe) * granule_size
 
 
-def get_excluded_fields(ogc_form: dict[str, set[str]]) -> list[str]:
+def get_excluded_fields(
+    ogc_form: list[dict[str, Any]] | dict[str, Any] | None
+) -> list[str]:
+    raise ValueError(ogc_form)
     if ogc_form is None:
         ogc_form = []
     if not isinstance(ogc_form, list):

--- a/cads_adaptors/costing.py
+++ b/cads_adaptors/costing.py
@@ -69,3 +69,11 @@ def estimate_size(
     granule_size: int = 1,
 ) -> int:
     return estimate_granules(form, selection, _constraints, safe=safe) * granule_size
+
+
+def estimate_number_of_fields(
+    form: dict[str, set[str]],
+    selection: dict[str, set[str]],
+) -> int:
+    number_of_fields = math.prod([len(v) for v in selection.values()])
+    return number_of_fields

--- a/cads_adaptors/costing.py
+++ b/cads_adaptors/costing.py
@@ -77,7 +77,6 @@ def estimate_size(
 def get_excluded_fields(
     ogc_form: list[dict[str, Any]] | dict[str, Any] | None
 ) -> list[str]:
-    raise ValueError(ogc_form)
     if ogc_form is None:
         ogc_form = []
     if not isinstance(ogc_form, list):

--- a/cads_adaptors/costing.py
+++ b/cads_adaptors/costing.py
@@ -1,5 +1,6 @@
 import itertools
 import math
+from typing import Any
 
 from . import constraints
 
@@ -72,8 +73,8 @@ def estimate_size(
 
 
 def estimate_number_of_fields(
-    form: dict[str, set[str]],
-    selection: dict[str, set[str]],
+    form: dict[str, set[str]], request: dict[str, dict[str, Any]]
 ) -> int:
+    selection = request["inputs"]
     number_of_fields = math.prod([len(v) for v in selection.values()])
     return number_of_fields

--- a/cads_adaptors/costing.py
+++ b/cads_adaptors/costing.py
@@ -74,32 +74,33 @@ def estimate_size(
     return estimate_granules(form, selection, _constraints, safe=safe) * granule_size
 
 
-def get_excluded_fields(
+def get_excluded_variables(
     ogc_form: list[dict[str, Any]] | dict[str, Any] | None
 ) -> list[str]:
     if ogc_form is None:
         ogc_form = []
     if not isinstance(ogc_form, list):
         ogc_form = [ogc_form]
-    excluded_fields = []
+    excluded_variables = []
     for schema in ogc_form:
         if schema["type"] in EXCLUDED_WIDGETS:
-            excluded_fields.append(schema["name"])
-    return excluded_fields
+            excluded_variables.append(schema["name"])
+    return excluded_variables
 
 
-def estimate_number_of_values(
-    form: dict[str, set[str]], request: dict[str, dict[str, Any]]
+def estimate_number_of_fields(
+    form: list[dict[str, Any]] | dict[str, Any] | None,
+    request: dict[str, dict[str, Any]],
 ) -> int:
-    excluded_fields = get_excluded_fields(form)
+    excluded_variables = get_excluded_variables(form)
     selection = request["inputs"]
     number_of_values = []
-    for field_id, field_value in selection.items():
-        if not isinstance(field_value, list):
-            field_value = [
-                field_value,
+    for variable_id, variable_value in selection.items():
+        if not isinstance(variable_value, list):
+            variable_value = [
+                variable_value,
             ]
-        if field_id not in excluded_fields:
-            number_of_values.append(len(field_value))
+        if variable_id not in excluded_variables:
+            number_of_values.append(len(variable_value))
     number_of_fields = math.prod(number_of_values)
     return number_of_fields

--- a/tests/test_10_costing.py
+++ b/tests/test_10_costing.py
@@ -222,3 +222,47 @@ def test_estimate_request_size() -> None:
 
     assert costing.estimate_size(form, {"param": {"Z", "T"}}, constraints) == 2
     assert costing.estimate_size(form, {"param": {"Z"}}, constraints) == 1
+
+
+def test_get_excluded_variables() -> None:
+    test_ogc_form = [
+        {"name": "var1", "type": "AllowedType"},
+        {"name": "var2", "type": "GeographicExtentWidget"},
+        {"name": "var3", "type": "DateRangeWidget"},
+    ]
+    exp_excluded_variables = ["var2", "var3"]
+    excluded_variables = costing.get_excluded_variables(test_ogc_form)
+    assert excluded_variables == exp_excluded_variables
+
+    exp_excluded_variables = []
+    excluded_variables = costing.get_excluded_variables(None)
+    assert excluded_variables == exp_excluded_variables
+
+    test_ogc_form = {"name": "var2", "type": "GeographicExtentWidget"}  # type: ignore
+    exp_excluded_variables = ["var2"]
+    excluded_variables = costing.get_excluded_variables(test_ogc_form)
+    assert excluded_variables == exp_excluded_variables
+
+
+def test_estimate_number_of_fields() -> None:
+    test_form = None
+    test_request = {"inputs": {"var1": ["value1", "value2"], "var2": "value3"}}
+    exp_number_of_fields = 2
+    number_of_fields = costing.estimate_number_of_fields(test_form, test_request)
+    assert number_of_fields == exp_number_of_fields
+
+    test_form = [
+        {"name": "var1", "type": "AllowedType"},
+        {"name": "var2", "type": "AllowedType"},
+        {"name": "var3", "type": "DateRangeWidget"},
+    ]
+    test_request = {
+        "inputs": {
+            "var1": ["value1", "value2"],
+            "var2": "value3",
+            "var3": ["value4", "value5"],
+        }
+    }
+    exp_number_of_fields = 2
+    number_of_fields = costing.estimate_number_of_fields(test_form, test_request)
+    assert number_of_fields == exp_number_of_fields


### PR DESCRIPTION
This PR implements default `estimate_consting` function.

This function, implemented in the `AbstractCdsAdaptor`, return the total number of selected values in a request, excluding a set of form widgets.