### PR TITLE
Hotfix - grib to netcdf conversion

### DIFF
--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -117,7 +117,10 @@ class MarsCdsAdaptor(cds.AbstractCdsAdaptor):
         data_format = request.pop("data_format", "grib")
 
         # Allow user to provide format conversion kwargs
-        convert_kwargs = request.pop("convert_kwargs", {})
+        convert_kwargs: dict[str, Any] = {
+            **self.config.get("format_conversion_kwargs", dict()),
+            **request.pop("format_conversion_kwargs", dict()),
+        }
 
         # To preserve existing ERA5 functionality the default download_format="as_source"
         request.setdefault("download_format", "as_source")

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -12,6 +12,9 @@ def convert_format(
     context: Context,
     **kwargs,
 ) -> list:
+    if isinstance(data_format, (list, tuple)):
+        data_format = data_format[0]
+
     # NOTE: The NetCDF compressed option will not be visible on the WebPortal, it is here for testing
     if data_format in ["netcdf", "nc", "netcdf_compressed"]:
         if data_format in ["netcdf_compressed"]:

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -8,14 +8,19 @@ DEFAULT_COMPRESSION_OPTIONS = {
 }
 
 
-def grib_to_netcdf_files(grib_file, compression_options=None, open_datasets_kwargs=None, **to_netcdf_kwargs):
-    fname, extension = os.path.splitext(grib_file)
+def grib_to_netcdf_files(
+    grib_file, compression_options=None, open_datasets_kwargs=None, **to_netcdf_kwargs
+):
+    fname, _ = os.path.splitext(os.path.basename(grib_file))
+    grib_file = os.path.realpath(grib_file)
+
     import cfgrib
-    
+
     if open_datasets_kwargs is None:
         open_datasets_kwargs = {
-            "chunks": {}   # Auto chunking
+            "chunks": {"time": 1, "step": 1, "plev": 1}  # Auto chunk by field
         }
+    print(open_datasets_kwargs)
     datasets = cfgrib.open_datasets(grib_file, **open_datasets_kwargs)
 
     if compression_options == "default":
@@ -37,5 +42,8 @@ def grib_to_netcdf_files(grib_file, compression_options=None, open_datasets_kwar
         out_fname = f"{fname}_{i}.nc"
         dataset.to_netcdf(out_fname, **to_netcdf_kwargs)
         out_nc_files.append(out_fname)
+
+    del dataset
+    del datasets
 
     return out_nc_files

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -8,11 +8,15 @@ DEFAULT_COMPRESSION_OPTIONS = {
 }
 
 
-def grib_to_netcdf_files(grib_file, compression_options=None, **to_netcdf_kwargs):
+def grib_to_netcdf_files(grib_file, compression_options=None, open_datasets_kwargs=None, **to_netcdf_kwargs):
     fname, extension = os.path.splitext(grib_file)
     import cfgrib
-
-    datasets = cfgrib.open_datasets(grib_file)
+    
+    if open_datasets_kwargs is None:
+        open_datasets_kwargs = {
+            "chunks": {}   # Auto chunking
+        }
+    datasets = cfgrib.open_datasets(grib_file, **open_datasets_kwargs)
 
     if compression_options == "default":
         compression_options = DEFAULT_COMPRESSION_OPTIONS

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -43,7 +43,4 @@ def grib_to_netcdf_files(
         dataset.to_netcdf(out_fname, **to_netcdf_kwargs)
         out_nc_files.append(out_fname)
 
-    del dataset
-    del datasets
-
     return out_nc_files


### PR DESCRIPTION
- Ensure "data_format" value is a string, can be a list, this fixes multi adaptor conversion
- Open data with chunks, default to field chunks (e.g. time=1, step=1, plev=1), this might be too conservative, but better safe than sorry
- Allow parsing of format conversion from the adaptor config using the "format_conversion_kwargs" key