### PR TITLE
grib to netcdf convertor is attached to class so over-writeable

### DIFF
--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -111,6 +111,9 @@ class DirectMarsCdsAdaptor(cds.AbstractCdsAdaptor):
 
 
 class MarsCdsAdaptor(cds.AbstractCdsAdaptor):
+    def convert_format(*args, **kwargs):
+        return convert_format(*args, **kwargs)
+
     def retrieve(self, request: Request) -> BinaryIO:
         # TODO: Remove legacy syntax all together
         data_format = request.pop("format", "grib")
@@ -134,7 +137,7 @@ class MarsCdsAdaptor(cds.AbstractCdsAdaptor):
             self.mapped_request, context=self.context, config=self.config
         )
 
-        paths = convert_format(
+        paths = self.convert_format(
             result, data_format, context=self.context, **convert_kwargs
         )
 

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -97,9 +97,14 @@ class MultiAdaptor(AbstractCdsAdaptor):
 
 
 class MultiMarsCdsAdaptor(MultiAdaptor):
+    def convert_format(*args, **kwargs):
+        from cads_adaptors.adaptors.mars import convert_format
+
+        return convert_format(*args, **kwargs)
+
     def retrieve(self, request: Request):
         """For MultiMarsCdsAdaptor we just want to apply mapping from each adaptor."""
-        from cads_adaptors.adaptors.mars import convert_format, execute_mars
+        from cads_adaptors.adaptors.mars import execute_mars
         from cads_adaptors.tools import adaptor_tools
 
         # Format of data files, grib or netcdf
@@ -142,7 +147,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
         )
         result = execute_mars(mapped_requests, context=self.context)
 
-        paths = convert_format(result, data_format, self.context, **convert_kwargs)
+        paths = self.convert_format(result, data_format, self.context, **convert_kwargs)
 
         if len(paths) > 1 and self.download_format == "as_source":
             self.download_format = "zip"

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -32,6 +32,8 @@ def grib_to_netcdf_files(
         if isinstance(open_datasets_kwargs, list):
             datasets: list[xr.Dataset] = []
             for open_ds_kwargs in open_datasets_kwargs:
+                # Default engine is cfgrib
+                open_ds_kwargs.setdefault("engine", "cfgrib")
                 datasets.append(xr.open_dataset(grib_file, **open_ds_kwargs))
         else:
             datasets = cfgrib.open_datasets(grib_file, **open_datasets_kwargs)

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 DEFAULT_COMPRESSION_OPTIONS = {
     "compression": "gzip",
@@ -9,20 +10,31 @@ DEFAULT_COMPRESSION_OPTIONS = {
 
 
 def grib_to_netcdf_files(
-    grib_file, compression_options=None, open_datasets_kwargs=None, **to_netcdf_kwargs
+    grib_file: str,
+    compression_options: None | str | dict[str, Any] = None,
+    open_datasets_kwargs: None | dict[str, Any] | list[dict[str, Any]] = None,
+    **to_netcdf_kwargs,
 ):
     fname, _ = os.path.splitext(os.path.basename(grib_file))
     grib_file = os.path.realpath(grib_file)
 
     import cfgrib
     import dask
+    import xarray as xr
 
     with dask.config.set(scheduler="threads"):
         if open_datasets_kwargs is None:
             open_datasets_kwargs = {
                 "chunks": {"time": 1, "step": 1, "plev": 1}  # Auto chunk by field
             }
-        datasets = cfgrib.open_datasets(grib_file, **open_datasets_kwargs)
+
+        # Option for manual split of the grib file into list of xr.Datasets using list of open_ds_kwargs
+        if isinstance(open_datasets_kwargs, list):
+            datasets: list[xr.Dataset] = []
+            for open_ds_kwargs in open_datasets_kwargs:
+                datasets.append(xr.open_dataset(grib_file, **open_ds_kwargs))
+        else:
+            datasets = cfgrib.open_datasets(grib_file, **open_datasets_kwargs)
 
         if compression_options == "default":
             compression_options = DEFAULT_COMPRESSION_OPTIONS


### PR DESCRIPTION
This PR will make it easier to provide alternate format convertors to the MARS adaptors.

Also allows users to provide open_dataset kwargs as a list, which will open the datasets using raw xarray, thus allowing dataset configuration to split the grib file into chunkale sections (necessary for multi origin datasets, e.g. seasonal)