### PR TITLE
ensure context is added to sub-adaptor

### DIFF
--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -56,7 +56,8 @@ class MultiAdaptor(AbstractCdsAdaptor):
         self.context.add_stdout(f"MultiAdaptor, full_request: {request}")
         for adaptor_tag, adaptor_desc in self.config["adaptors"].items():
             this_adaptor = adaptor_tools.get_adaptor(
-                {**adaptor_desc}, self.form,
+                {**adaptor_desc},
+                self.form,
             )
             # Set the sub-adaptor context to the MultiAdaptor context
             this_adaptor.context = self.context

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -49,11 +49,9 @@ class MultiAdaptor(AbstractCdsAdaptor):
         sub_adaptors = {}
         for adaptor_tag, adaptor_desc in self.config["adaptors"].items():
             this_adaptor = adaptor_tools.get_adaptor(
-                {**adaptor_desc},
+                adaptor_desc | {"context": self.context},
                 self.form,
             )
-            # Set the sub-adaptor context to the MultiAdaptor context
-            this_adaptor.context = self.context
             this_values = adaptor_desc.get("values", {})
 
             this_request = self.split_request(

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -53,15 +53,19 @@ class MultiAdaptor(AbstractCdsAdaptor):
 
         these_requests = {}
         exception_logs: dict[str, str] = {}
-        self.context.logger.debug(f"MultiAdaptor, full_request: {request}")
+        self.context.add_stdout(f"MultiAdaptor, full_request: {request}")
         for adaptor_tag, adaptor_desc in self.config["adaptors"].items():
-            this_adaptor = adaptor_tools.get_adaptor(adaptor_desc, self.form)
+            this_adaptor = adaptor_tools.get_adaptor(
+                {**adaptor_desc}, self.form,
+            )
+            # Set the sub-adaptor context to the MultiAdaptor context
+            this_adaptor.context = self.context
             this_values = adaptor_desc.get("values", {})
 
             this_request = self.split_request(
                 request, this_values, **this_adaptor.config
             )
-            self.context.logger.debug(
+            self.context.add_stdout(
                 f"MultiAdaptor, {adaptor_tag}, this_request: {this_request}"
             )
 
@@ -125,7 +129,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
         self._pre_retrieve(request, default_download_format="as_source")
 
         mapped_requests = []
-        self.context.logger.debug(f"MultiMarsCdsAdaptor, full_request: {request}")
+        self.context.add_stdout(f"MultiMarsCdsAdaptor, full_request: {request}")
         for adaptor_tag, adaptor_desc in self.config["adaptors"].items():
             this_adaptor = adaptor_tools.get_adaptor(adaptor_desc, self.form)
             this_values = adaptor_desc.get("values", {})
@@ -133,7 +137,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
             this_request = self.split_request(
                 request, this_values, **this_adaptor.config
             )
-            self.context.logger.debug(
+            self.context.add_stdout(
                 f"MultiMarsCdsAdaptor, {adaptor_tag}, this_request: {this_request}"
             )
 
@@ -142,7 +146,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
                     mapping.apply_mapping(this_request, this_adaptor.mapping)
                 )
 
-        self.context.logger.debug(
+        self.context.add_stdout(
             f"MultiMarsCdsAdaptor, mapped_requests: {mapped_requests}"
         )
         result = execute_mars(mapped_requests, context=self.context)

--- a/tests/test_20_adaptor_multi.py
+++ b/tests/test_20_adaptor_multi.py
@@ -1,3 +1,4 @@
+from cads_adaptors import AbstractAdaptor
 from cads_adaptors.adaptors import multi
 
 FORM = {
@@ -54,5 +55,17 @@ def test_multi_adaptor_split_adaptors():
         REQUEST,
     )
 
-    for s_a in list(sub_adaptors):
-        assert s_a.context is multi_adaptor.context
+    # Check that the sub-adaptors have the correct values
+    for adaptor in ["mean", "max"]:
+        sub_adaptor_request = sub_adaptors[adaptor][1]
+        sub_adaptor_request.pop("download_format")
+        sub_adaptor_request.pop("receipt")
+        assert sub_adaptor_request == ADAPTOR_CONFIG["adaptors"][adaptor]["values"]
+
+    for adaptor_tag, [adaptor, req] in sub_adaptors.items():
+        assert isinstance(adaptor_tag, str)
+        assert isinstance(adaptor, AbstractAdaptor)
+        assert isinstance(req, dict)
+
+        # Check context is inherited from parent
+        assert adaptor.context is multi_adaptor.context

--- a/tests/test_20_adaptor_multi.py
+++ b/tests/test_20_adaptor_multi.py
@@ -33,7 +33,7 @@ ADAPTOR_CONFIG = {
 }
 
 
-def test_multi_adaptor_split():
+def test_multi_adaptor_split_requests():
     multi_adaptor = multi.MultiAdaptor(FORM, **ADAPTOR_CONFIG)
 
     split_mean = multi_adaptor.split_request(
@@ -45,3 +45,14 @@ def test_multi_adaptor_split():
         REQUEST, multi_adaptor.config["adaptors"]["max"]["values"]
     )
     assert split_max == ADAPTOR_CONFIG["adaptors"]["max"]["values"]
+
+
+def test_multi_adaptor_split_adaptors():
+    multi_adaptor = multi.MultiAdaptor(FORM, **ADAPTOR_CONFIG)
+
+    sub_adaptors = multi_adaptor.split_adaptors(
+        REQUEST,
+    )
+
+    for s_a in list(sub_adaptors):
+        assert s_a.context is multi_adaptor.context


### PR DESCRIPTION
closes #121 
In short, the multi adaptor spawns sub-adaptors. I was not attaching the context to the sub-adaptor, hence the logs were not going to the database.

I also updated the methods I had for handling the logs.

do you agree that ovrewriting the context attribute is a good optino, or should I pass the context to the adaptor class initialisation?