### PR TITLE
add InvalidRequest exception

### DIFF
--- a/cads_adaptors/adaptors/__init__.py
+++ b/cads_adaptors/adaptors/__init__.py
@@ -95,7 +95,24 @@ class AbstractAdaptor(abc.ABC):
             self.context = context
 
     @abc.abstractmethod
-    def normalise_request(self, request: Request) -> dict[str, Any]:
+    def normalise_request(self, request: Request) -> Request:
+        """Apply any normalisation to the request before validation.
+
+        Parameters
+        ----------
+        request : Request
+            Incoming request.
+
+        Returns
+        -------
+        Request
+            Normalised request.
+
+        Raises
+        ------
+        cads_adaptors.exceptions.InvalidRequest
+            If the request is invalid.
+        """
         pass
 
     @abc.abstractmethod

--- a/cads_adaptors/exceptions.py
+++ b/cads_adaptors/exceptions.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import attrs
 
-
-@attrs.define
 class InvalidRequest(Exception):
     """Raised when an invalid request is sent to the adaptor."""
-
-    message: str = "Invalid request"

--- a/cads_adaptors/exceptions.py
+++ b/cads_adaptors/exceptions.py
@@ -1,0 +1,22 @@
+# Copyright 2022, European Union.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import attrs
+
+
+@attrs.define
+class InvalidRequest(Exception):
+    """Raised when an invalid request is sent to the adaptor."""
+
+    message: str = "Invalid request"


### PR DESCRIPTION
This PR adds a custom exception to be raised by the normalise_request method when a submitted request is invalid.

**Needed by**
- https://github.com/ecmwf-projects/cads-processing-api-service/pull/186