### PR TITLE
Hotfix/intersect constraints with whole datacubes

### DIFF
--- a/cads_adaptors/constraints.py
+++ b/cads_adaptors/constraints.py
@@ -617,6 +617,8 @@ def legacy_intersect_constraints(
             }
 
     """
+    if len(constraints) == 0:
+        return [request]
     requests = []
     constraints = parse_constraints(constraints)
     constrained_fields = set(itertools.chain.from_iterable(constraints))

--- a/cads_adaptors/constraints.py
+++ b/cads_adaptors/constraints.py
@@ -617,7 +617,7 @@ def legacy_intersect_constraints(
             }
 
     """
-    if len(constraints) == 0:
+    if constraints is None or len(constraints) == 0:
         return [request]
     requests = []
     constraints = parse_constraints(constraints)

--- a/tests/test_10_constraints.py
+++ b/tests/test_10_constraints.py
@@ -381,7 +381,6 @@ def test_legacy_intersect_constraints():
     assert actual == expected
 
 
-
 def test_legacy_intersect_empty_constraints():
     raw_constraints = []
     request = {

--- a/tests/test_10_constraints.py
+++ b/tests/test_10_constraints.py
@@ -383,14 +383,6 @@ def test_legacy_intersect_constraints():
 
 def test_legacy_intersect_empty_constraints():
     raw_constraints = []
-    request = {
-        "variable": ["surface_downwelling_shortwave_radiation", "electricity_demand"],
-        "spatial_aggregation": "country_level",
-        "temporal_aggregation": ["monthly"],
-        "energy_product_type": ["energy"],
-        "experiment": ["rcp_8_5"],
-        "rcm": ["racmo22e"],
-        "gcm": ["hadgem2_es"],
-    }
+    request = {"foo": "bar"}
     actual = constraints.legacy_intersect_constraints(request, raw_constraints)
     assert actual == [request]

--- a/tests/test_10_constraints.py
+++ b/tests/test_10_constraints.py
@@ -385,4 +385,4 @@ def test_legacy_intersect_empty_constraints():
     raw_constraints = []
     request = {"foo": "bar"}
     actual = constraints.legacy_intersect_constraints(request, raw_constraints)
-    assert actual == [request]
+    assert actual == [{"foo": "bar"}]

--- a/tests/test_10_constraints.py
+++ b/tests/test_10_constraints.py
@@ -379,3 +379,19 @@ def test_legacy_intersect_constraints():
     ]
     actual = constraints.legacy_intersect_constraints(request, raw_constraints)
     assert actual == expected
+
+
+
+def test_legacy_intersect_empty_constraints():
+    raw_constraints = []
+    request = {
+        "variable": ["surface_downwelling_shortwave_radiation", "electricity_demand"],
+        "spatial_aggregation": "country_level",
+        "temporal_aggregation": ["monthly"],
+        "energy_product_type": ["energy"],
+        "experiment": ["rcp_8_5"],
+        "rcm": ["racmo22e"],
+        "gcm": ["hadgem2_es"],
+    }
+    actual = constraints.legacy_intersect_constraints(request, raw_constraints)
+    assert actual == [request]


### PR DESCRIPTION
The first implementation did not account for the trick we do with "complete hypercube" datasets. When the dataset is decribed by a  single constriant, i.e. a complete hypercube, the constraints.json is an empty list. Therefore, if the length of constraints is 0, the method should return the request in a list.

Test added