### PR TITLE
Normalize request basic

### DIFF
--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -76,8 +76,14 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         return costs
 
     def normalise_request(self, request: Request) -> dict[str, Any]:
-        # TODO: cast to dict[str, list]
-        return request
+        assert isinstance(request, dict)
+        normalised_request = {}
+        for key, values in request.items():
+            values = [str(val) for val in ensure_list(values) if val is not None]
+            values = [v for v in values if len(v)]
+            if len(values):
+                normalised_request[key] = values
+        return normalised_request
 
     def get_licences(self, request: Request) -> list[tuple[str, int]]:
         return self.licences

--- a/cads_adaptors/tools/general.py
+++ b/cads_adaptors/tools/general.py
@@ -1,5 +1,7 @@
 def ensure_list(input_item):
     """Ensure that item is a list, generally for iterability."""
-    if not isinstance(input_item, list):
-        return [input_item]
-    return input_item
+    if isinstance(input_item, list):
+        return input_item
+    if isinstance(input_item, (tuple, set)):
+        return list(input_item)
+    return [input_item]

--- a/tests/test_14_abstract_cds.py
+++ b/tests/test_14_abstract_cds.py
@@ -24,19 +24,28 @@ def test_normalize_request(in_value):
 
 def test_normalize_request_complex():
     this_adaptor = DummyCdsAdaptor({}, collection_id="test-collection")
-    request = this_adaptor.normalise_request(
-        {
-            "test": 1,
-            "test2": "1",
-            "test3": [1, "2"],
-            "test4": (1, "2"),
-            "test5": {1, "2"},
-        }
-    )
-    assert request == {
+    request_in = {
+        "test": 1,
+        "test2": "1",
+        "test3": [1, "2"],
+        "test4": (1, "2"),
+    }
+    assert this_adaptor.normalise_request(request_in) == {
         "test": ["1"],
         "test2": ["1"],
         "test3": ["1", "2"],
         "test4": ["1", "2"],
-        "test5": ["1", "2"],
     }
+
+    request_in.update(
+        {
+            "test5": {1, "2"},
+        }
+    )
+    request_out = this_adaptor.normalise_request(request_in)
+    assert request_out["test"] == ["1"]
+    assert request_out["test2"] == ["1"]
+    assert request_out["test3"] == ["1", "2"]
+    assert request_out["test4"] == ["1", "2"]
+    # Test 5 is a set, so order not guaranteed
+    assert sorted(request_out["test5"]) == ["1", "2"]

--- a/tests/test_14_abstract_cds.py
+++ b/tests/test_14_abstract_cds.py
@@ -1,0 +1,35 @@
+import pytest
+
+from cads_adaptors import DummyCdsAdaptor
+
+
+@pytest.mark.parametrize(
+    "in_value",
+    (
+        1, "1", [1], (1,), {1}, ["1"], {"1"}, ("1",),
+    ),
+)
+def test_normalize_request(in_value):
+    this_adaptor = DummyCdsAdaptor({}, collection_id="test-collection")
+    request = this_adaptor.normalise_request({"test": in_value})
+    assert request == {"test": ["1"]}
+
+
+def test_normalize_request_complex():
+    this_adaptor = DummyCdsAdaptor({}, collection_id="test-collection")
+    request = this_adaptor.normalise_request({
+        "test": 1,
+        "test2": "1",
+        "test3": [1, "2"],
+        "test4": (1, "2"),
+        "test5": {1, "2"}
+    })
+    assert request == {
+        "test": ["1"],
+        "test2": ["1"],
+        "test3": ["1", "2"],
+        "test4": ["1", "2"],
+        "test5": ["1", "2"]
+    }
+
+    

--- a/tests/test_14_abstract_cds.py
+++ b/tests/test_14_abstract_cds.py
@@ -6,7 +6,14 @@ from cads_adaptors import DummyCdsAdaptor
 @pytest.mark.parametrize(
     "in_value",
     (
-        1, "1", [1], (1,), {1}, ["1"], {"1"}, ("1",),
+        1,
+        "1",
+        [1],
+        (1,),
+        {1},
+        ["1"],
+        {"1"},
+        ("1",),
     ),
 )
 def test_normalize_request(in_value):
@@ -17,19 +24,19 @@ def test_normalize_request(in_value):
 
 def test_normalize_request_complex():
     this_adaptor = DummyCdsAdaptor({}, collection_id="test-collection")
-    request = this_adaptor.normalise_request({
-        "test": 1,
-        "test2": "1",
-        "test3": [1, "2"],
-        "test4": (1, "2"),
-        "test5": {1, "2"}
-    })
+    request = this_adaptor.normalise_request(
+        {
+            "test": 1,
+            "test2": "1",
+            "test3": [1, "2"],
+            "test4": (1, "2"),
+            "test5": {1, "2"},
+        }
+    )
     assert request == {
         "test": ["1"],
         "test2": ["1"],
         "test3": ["1", "2"],
         "test4": ["1", "2"],
-        "test5": ["1", "2"]
+        "test5": ["1", "2"],
     }
-
-    


### PR DESCRIPTION
A basic system wide normalise_request method that ensures that:
- Requests are dict[str, list[str]]
- The values of the request dictionary must have length>=1
