### PR TITLE
dtype issues for intersect_constraints

### DIFF
--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -42,7 +42,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         return [
             self.normalise_request(request)
             for request in constraints.legacy_intersect_constraints(
-                request, self.constraints
+                request, self.constraints, context=self.context
             )
         ]
 

--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -19,7 +19,7 @@ class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
         # Convert request to list of URLs
         requests = [
             self.apply_mapping(request)
-            for request in self.intersect_constraints(request, self.context)
+            for request in self.intersect_constraints(request)
         ]
         requests_urls = url_tools.requests_to_urls(
             requests,

--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -19,7 +19,7 @@ class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
         # Convert request to list of URLs
         requests = [
             self.apply_mapping(request)
-            for request in self.intersect_constraints(request)
+            for request in self.intersect_constraints(request, self.context)
         ]
         requests_urls = url_tools.requests_to_urls(
             requests,

--- a/cads_adaptors/constraints.py
+++ b/cads_adaptors/constraints.py
@@ -539,8 +539,9 @@ def gen_time_range_from_string(string: str) -> DateTimeRange:
 
 
 def legacy_intersect_constraints(
-    request: dict[str, Any], constraints: list[dict[str, Any]] | dict[str, Any] | None,
-    context: adaptors.Context = adaptors.Context()
+    request: dict[str, Any],
+    constraints: list[dict[str, Any]] | dict[str, Any] | None,
+    context: adaptors.Context = adaptors.Context(),
 ) -> list[dict[str, list[Any]]]:
     """
     'Constrain' a request by intersecting it with the constraints.
@@ -686,10 +687,9 @@ def legacy_intersect_constraints(
             "If using the cdsapi, please ensure that all values are strings or lists of strings.\n"
             "If you believe this to be a data store error, please contact user support."
         )
-        raise exceptions.ConstraintError(
-            "Your request has not produce a valid combination of values, please check your selection.\n"
-            "If using the cdsapi, please ensure that all values are strings or lists of strings.\n"
-            "If you believe this to be a data store error, please contact user support."
-        )   
-     
+        raise exceptions.InvalidRequest(
+            "Request has not produce a valid combination of values, please check your selection.\n"
+            f"{request}"
+        )
+
     return requests

--- a/cads_adaptors/constraints.py
+++ b/cads_adaptors/constraints.py
@@ -539,7 +539,8 @@ def gen_time_range_from_string(string: str) -> DateTimeRange:
 
 
 def legacy_intersect_constraints(
-    request: dict[str, Any], constraints: list[dict[str, Any]] | dict[str, Any] | None
+    request: dict[str, Any], constraints: list[dict[str, Any]] | dict[str, Any] | None,
+    context: adaptors.Context = adaptors.Context()
 ) -> list[dict[str, list[Any]]]:
     """
     'Constrain' a request by intersecting it with the constraints.
@@ -679,4 +680,16 @@ def legacy_intersect_constraints(
         if len(output_request) != 0:
             requests.append(output_request)
 
+    if len(requests) == 0:
+        context.add_user_visible_error(
+            "Your request has not produce a valid combination of values, please check your selection.\n"
+            "If using the cdsapi, please ensure that all values are strings or lists of strings.\n"
+            "If you believe this to be a data store error, please contact user support."
+        )
+        raise exceptions.ConstraintError(
+            "Your request has not produce a valid combination of values, please check your selection.\n"
+            "If using the cdsapi, please ensure that all values are strings or lists of strings.\n"
+            "If you believe this to be a data store error, please contact user support."
+        )   
+     
     return requests

--- a/cads_adaptors/constraints.py
+++ b/cads_adaptors/constraints.py
@@ -664,7 +664,7 @@ def legacy_intersect_constraints(
             constrained_field_value = [
                 v
                 for v in ensure_sequence(output_request.get(field, []))
-                if v in constraint[field]
+                if str(v) in constraint[field]
             ]
 
             # If the intersection is empty, the request as a whole does not

--- a/tests/test_10_constraints.py
+++ b/tests/test_10_constraints.py
@@ -386,3 +386,10 @@ def test_legacy_intersect_empty_constraints():
     request = {"foo": "bar"}
     actual = constraints.legacy_intersect_constraints(request, raw_constraints)
     assert actual == [{"foo": "bar"}]
+
+
+def test_legacy_intersect_dtype_differences():
+    raw_constraints = [{"foo": ["1", "2"], "bar": "3"}]
+    request = {"foo": 1, "bar": [3, 4]}
+    actual = constraints.legacy_intersect_constraints(request, raw_constraints)
+    assert actual == [{"foo": [1], "bar": [3]}]


### PR DESCRIPTION
Current implementation fails when the input request has a dtype (e.g. int) which is not string, constraints.json config files are always strings.