### PR TITLE
robust ensure_list, with tests

### DIFF
--- a/cads_adaptors/tools/general.py
+++ b/cads_adaptors/tools/general.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+
 def ensure_list(input_item: Any) -> list:
     """Ensure that item is a list, generally for iterability."""
     if isinstance(input_item, (list, tuple, set)):

--- a/cads_adaptors/tools/general.py
+++ b/cads_adaptors/tools/general.py
@@ -1,5 +1,9 @@
-def ensure_list(input_item):
+from typing import Any
+
+def ensure_list(input_item: Any) -> list:
     """Ensure that item is a list, generally for iterability."""
-    if not isinstance(input_item, list):
-        return [input_item]
-    return input_item
+    if isinstance(input_item, (list, tuple, set)):
+        return list(input_item)
+    if input_item is None:
+        return []
+    return [input_item]

--- a/tests/test_10_general_tools.py
+++ b/tests/test_10_general_tools.py
@@ -1,12 +1,14 @@
 import pytest
+
 from cads_adaptors.tools import general
+
 
 @pytest.mark.parametrize(
     "input_item, expected_output",
     [
         ("test", ["test"]),
         (1, [1]),
-        (1., [1.]),
+        (1.0, [1.0]),
         (object, [object]),
         ({"test"}, ["test"]),
         (["test", "test2"], ["test", "test2"]),

--- a/tests/test_10_general_tools.py
+++ b/tests/test_10_general_tools.py
@@ -1,0 +1,22 @@
+import pytest
+from cads_adaptors.tools import general
+
+@pytest.mark.parametrize(
+    "input_item, expected_output",
+    [
+        ("test", ["test"]),
+        (1, [1]),
+        (1., [1.]),
+        (object, [object]),
+        ({"test"}, ["test"]),
+        (["test", "test2"], ["test", "test2"]),
+        (["test"], ["test"]),
+        ((1, 2), [1, 2]),
+        ((1,), [1]),
+        ((), []),
+        ({"test": "test"}, [{"test": "test"}]),
+        (None, []),
+    ],
+)
+def test_general_ensure_list(input_item, expected_output):
+    assert general.ensure_list(input_item) == expected_output


### PR DESCRIPTION
The ensure list was not robust enough, this means that it will convert tuples and sets to lists instead of putting them into a list as the first element