### PR TITLE
Slow progress bar for reduced messages

### DIFF
--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -53,7 +53,10 @@ def try_download(urls: List[str], context: Context, **kwargs) -> List[str]:
         try:
             context.add_stdout(f"Downloading {url} to {path}")
             multiurl.download(
-                url, path, progress_bar=functools.partial(tqdm, file=context, minterval=5), **kwargs
+                url,
+                path,
+                progress_bar=functools.partial(tqdm, file=context, minterval=5),
+                **kwargs,
             )
         except Exception as e:
             context.add_stdout(f"Failed download for URL: {url}\nException: {e}")

--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -55,7 +55,7 @@ def try_download(urls: List[str], context: Context, **kwargs) -> List[str]:
             multiurl.download(
                 url,
                 path,
-                progress_bar=functools.partial(tqdm, file=context, minterval=5),
+                progress_bar=functools.partial(tqdm, file=context, mininterval=5),
                 **kwargs,
             )
         except Exception as e:

--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -53,7 +53,7 @@ def try_download(urls: List[str], context: Context, **kwargs) -> List[str]:
         try:
             context.add_stdout(f"Downloading {url} to {path}")
             multiurl.download(
-                url, path, progress_bar=functools.partial(tqdm, file=context), **kwargs
+                url, path, progress_bar=functools.partial(tqdm, file=context, minterval=5), **kwargs
             )
         except Exception as e:
             context.add_stdout(f"Failed download for URL: {url}\nException: {e}")


### PR DESCRIPTION
Slow the interval which the progress bar updates for reduced messages.

mininterval is the time in seconds that the progress bar updates, default is 0.1, which results in messages being created every 0.1 seconds. This PR sets a minimum interval for updating to 5 seconds. We can modify this again in the future, but I think this is good enough to reduce the messages to a sensible amount.