### PR TITLE
Optimize the header and also to_csv call

### DIFF
--- a/cads_adaptors/adaptors/cadsobs/csv.py
+++ b/cads_adaptors/adaptors/cadsobs/csv.py
@@ -26,8 +26,8 @@ def to_csv(
     # Beware this will not work with old dask versions because of a bug
     # https://github.com/dask/dask/issues/10414
     cdm_lite_dataset.to_dask_dataframe().astype("str").to_csv(
-        output_path, index=False, single_file=True, mode="a", compute=False
-    ).compute(optimize_graph=True)
+        output_path, index=False, single_file=True, mode="a"
+    )
     return output_path
 
 


### PR DESCRIPTION
Calling compute after to_csv should not make any different, but somehow it does, when looking with the profiler.

The peak memory usages were identified using https://github.com/pythonspeed/filprofiler