### PR TITLE
bugfix for multi-adaptor

### DIFF
--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -24,22 +24,23 @@ class MultiAdaptor(AbstractCdsAdaptor):
         this_request = {}
         # loop over keys in the full_request
         for key, req_vals in full_request.items():
-            # filter for values relevant to this_adaptor:
+            # If dont_split_key, then copy the key and values to the new request
             if key in ensure_list(dont_split_keys):
-                these_vals = req_vals
+                this_request[key] = req_vals
             else:
+                # filter for values relevant to this_adaptor:
                 these_vals = [
                     v
                     for v in ensure_list(req_vals)
                     if str(v) in this_values.get(key, [])
                 ]
-            if len(these_vals) > 0:
-                # if values then add to request
-                this_request[key] = these_vals
-            elif key in required_keys:
-                # If a required key is missing, then return an empty dictionary.
-                #  optional keys must be set in the adaptor.json via gecko
-                return dict()
+                if len(these_vals) > 0:
+                    # if values then add to request
+                    this_request[key] = these_vals
+                elif key in required_keys:
+                    # If a required key is missing, then return an empty dictionary.
+                    #  optional keys must be set in the adaptor.json via gecko
+                    return dict()
 
         # Our request may not have included all keys, so do a final check that all required keys are present
         if not all([key in this_request for key in required_keys]):

--- a/tests/test_20_adaptor_multi.py
+++ b/tests/test_20_adaptor_multi.py
@@ -84,31 +84,40 @@ def test_multi_adaptor_split_requests_dont_split_keys():
     assert "dont_split" in split_mean_dont_split_area
 
     # dont_split_keys as integer dtype
-    request["dont_split"] = 1
-    split_mean_dont_split_int = multi_adaptor.split_request(
+    request["dont_split"] = "1"
+    split_mean_dont_split = multi_adaptor.split_request(
         request,
         multi_adaptor.config["adaptors"]["mean"]["values"],
         dont_split_keys=["dont_split"],
     )
-    assert "dont_split" in split_mean_dont_split_int
+    assert "dont_split" in split_mean_dont_split
+
+    # dont_split_keys as integer dtype
+    request["dont_split"] = 1
+    split_mean_dont_split = multi_adaptor.split_request(
+        request,
+        multi_adaptor.config["adaptors"]["mean"]["values"],
+        dont_split_keys=["dont_split"],
+    )
+    assert "dont_split" in split_mean_dont_split
 
     # dont_split_keys as float dtype
     request["dont_split"] = 1.0
-    split_mean_dont_split_int = multi_adaptor.split_request(
+    split_mean_dont_split = multi_adaptor.split_request(
         request,
         multi_adaptor.config["adaptors"]["mean"]["values"],
         dont_split_keys=["dont_split"],
     )
-    assert "dont_split" in split_mean_dont_split_int
+    assert "dont_split" in split_mean_dont_split
 
     # dont_split_keys as dict dtype
     request["dont_split"] = {"a": 1}
-    split_mean_dont_split_int = multi_adaptor.split_request(
+    split_mean_dont_split = multi_adaptor.split_request(
         request,
         multi_adaptor.config["adaptors"]["mean"]["values"],
         dont_split_keys=["dont_split"],
     )
-    assert "dont_split" in split_mean_dont_split_int
+    assert "dont_split" in split_mean_dont_split
 
     # Area is dont_split as default
     request["area"] = [1, 2, 3, 4]

--- a/tests/test_20_adaptor_multi.py
+++ b/tests/test_20_adaptor_multi.py
@@ -92,6 +92,24 @@ def test_multi_adaptor_split_requests_dont_split_keys():
     )
     assert "dont_split" in split_mean_dont_split_int
 
+    # dont_split_keys as float dtype
+    request["dont_split"] = 1.0
+    split_mean_dont_split_int = multi_adaptor.split_request(
+        request,
+        multi_adaptor.config["adaptors"]["mean"]["values"],
+        dont_split_keys=["dont_split"],
+    )
+    assert "dont_split" in split_mean_dont_split_int
+
+    # dont_split_keys as dict dtype
+    request["dont_split"] = {"a": 1}
+    split_mean_dont_split_int = multi_adaptor.split_request(
+        request,
+        multi_adaptor.config["adaptors"]["mean"]["values"],
+        dont_split_keys=["dont_split"],
+    )
+    assert "dont_split" in split_mean_dont_split_int
+
     # Area is dont_split as default
     request["area"] = [1, 2, 3, 4]
     split_max_split_area = multi_adaptor.split_request(

--- a/tests/test_20_adaptor_multi.py
+++ b/tests/test_20_adaptor_multi.py
@@ -74,6 +74,7 @@ def test_multi_adaptor_split_requests_dont_split_keys():
     multi_adaptor = multi.MultiAdaptor(FORM, **ADAPTOR_CONFIG)
 
     request = REQUEST.copy()
+    # dont_split_keys as list dtype
     request["dont_split"] = [1, 2, 3, 4]
     split_mean_dont_split_area = multi_adaptor.split_request(
         request,
@@ -81,6 +82,15 @@ def test_multi_adaptor_split_requests_dont_split_keys():
         dont_split_keys=["dont_split"],
     )
     assert "dont_split" in split_mean_dont_split_area
+
+    # dont_split_keys as integer dtype
+    request["dont_split"] = 1
+    split_mean_dont_split_int = multi_adaptor.split_request(
+        request,
+        multi_adaptor.config["adaptors"]["mean"]["values"],
+        dont_split_keys=["dont_split"],
+    )
+    assert "dont_split" in split_mean_dont_split_int
 
     # Area is dont_split as default
     request["area"] = [1, 2, 3, 4]


### PR DESCRIPTION
Handle when a dont_split_key does not have length, e.g. if it is an integer or float value

I simplifed it so that the dont_split_key input value is inserted directly into the new request dictionary with no further checks.