### PR TITLE
Introduce kwargs in estimate_costs

### DIFF
--- a/cads_adaptors/adaptors/__init__.py
+++ b/cads_adaptors/adaptors/__init__.py
@@ -154,7 +154,7 @@ class AbstractAdaptor(abc.ABC):
         request : Request
             Incoming request.
         **kwargs : Any
-            Additional parameters.
+            Additional parameters, specific to the particular method's implementation.
 
         Returns
         -------

--- a/cads_adaptors/adaptors/__init__.py
+++ b/cads_adaptors/adaptors/__init__.py
@@ -156,7 +156,7 @@ class DummyAdaptor(AbstractAdaptor):
     def apply_constraints(self, request: Request) -> dict[str, Any]:
         return {}
 
-    def estimate_costs(self, request: Request) -> dict[str, int]:
+    def estimate_costs(self, request: Request, **kwargs: Any) -> dict[str, int]:
         size = int(request.get("size", 0))
         time = int(request.get("time", 0.0))
         return {"size": size, "time": time}

--- a/cads_adaptors/adaptors/__init__.py
+++ b/cads_adaptors/adaptors/__init__.py
@@ -140,7 +140,7 @@ class AbstractAdaptor(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def estimate_costs(self, request: Request) -> dict[str, int]:
+    def estimate_costs(self, request: Request, **kwargs: Any) -> dict[str, int]:
         pass
 
     @abc.abstractmethod

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -49,9 +49,8 @@ class AbstractCdsAdaptor(AbstractAdaptor):
     def apply_mapping(self, request: Request) -> Request:
         return mapping.apply_mapping(request, self.mapping)
 
-    def estimate_costs(
-        self, request: Request, cost_threshold: str = "max_costs"
-    ) -> dict[str, int]:
+    def estimate_costs(self, request: Request, **kwargs: Any) -> dict[str, int]:
+        cost_threshold = kwargs.get("cost_threshold", "max_costs")
         costing_config: dict[str, Any] = self.config.get("costing", dict())
         costing_kwargs: dict[str, Any] = costing_config.get("costing_kwargs", dict())
         cost_threshold = (


### PR DESCRIPTION
This PR introduce `**kwargs` in both `AbstractAdaptor` and `AbstractCdsAdaptor`'s `estimate_costs` method.
The ratio is to let developers introduce new parameters in methods of child adaptor classes without the need to accordingly update the signature of correspondent methods in parent class.

**Needed by**
- https://github.com/ecmwf-projects/cads-processing-api-service/pull/195