### PR TITLE
netcdf legacy

### DIFF
--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -330,6 +330,13 @@ def result_to_netcdf_legacy_files(
         command = ensure_list(command)
         os.system(" ".join(command + ["-o", out_fname, grib_file]))
 
+    if len(nc_files) == 0:
+        message = (
+            "We are unable to convert this GRIB data to netCDF, "
+            "please download as GRIB and convert to netCDF locally.\n"
+        )
+        add_user_log_and_raise_error(message, context=context, thisError=RuntimeError)
+    
     return nc_files
 
 

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -299,7 +299,6 @@ def result_to_netcdf_legacy_files(
             context=context,
             thisError=ValueError,
         )
-    print(f"grib_to_netcdf in results: {result}")
 
     if filter_rules:
         # Filter the grib files to netCDFable chunks (in replacement of split_on in legacy system)
@@ -324,14 +323,13 @@ def result_to_netcdf_legacy_files(
                 filtered_results[f"{out_fname_base}_{filter_base}"] = filter_file
         result = filtered_results
 
-    print(f"Grib files for conversion: {result}")
     nc_files = []
     for out_fname_base, grib_file in result.items():
         out_fname = f"{out_fname_base}.nc"
         nc_files.append(out_fname)
         command = ensure_list(command)
         os.system(" ".join(command + ["-o", out_fname, grib_file]))
-    
+
     return nc_files
 
 

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -304,12 +304,12 @@ def result_to_netcdf_legacy_files(
         # Filter the grib files to netCDFable chunks (in replacement of split_on in legacy system)
         here = os.getcwd()
         os.system(f"echo {filter_rules} > {here}/filter_rules")
-        print(filter_rules)
+        print(here, filter_rules)
         os.system(f"cat {here}/filter_rules")
         filtered_results = {}
         for out_fname_base, grib_file in result.items():
             import glob
-
+            print(out_fname_base)
             full_grib_path = os.path.realpath(grib_file)
             temp_filter_folder = (
                 f"{os.path.dirname(full_grib_path)}/{out_fname_base}.filtered"
@@ -322,6 +322,7 @@ def result_to_netcdf_legacy_files(
             )
             os.chdir(here)
             for filter_file in glob.glob(f"{temp_filter_folder}/*.grib*"):
+                print(filter_file)
                 filter_base = os.path.splitext(os.path.basename(filter_file))
                 filtered_results[f"{out_fname_base}_{filter_base}"] = filter_file
         result = filtered_results

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -322,8 +322,12 @@ def result_to_netcdf_legacy_files(
                 filtered_results[f"{out_fname_base}_{filter_base}"] = filter_file
         result = filtered_results
 
+    nc_files = []
     for out_fname_base, grib_file in result.items():
+        nc_files.append(f"{out_fname_base}.nc")
         os.system(f"{command} -o {out_fname_base}.nc  {grib_file}")
+    
+    return nc_files
 
 
 def unknown_filetype_to_grib_files(

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -298,6 +298,7 @@ def result_to_netcdf_legacy_files(
             context=context,
             thisError=ValueError,
         )
+    print(f"grib_to_netcdf in results: {result}")
 
     if filter_rules:
         # Filter the grib files to netCDFable chunks (in replacement of split_on in legacy system)

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -305,11 +305,9 @@ def result_to_netcdf_legacy_files(
         here = os.getcwd()
         with open(f"{here}/filter_rules", "w") as f:
             f.write(filter_rules)
-        os.system(f"echo POTATO; cat {here}/filter_rules")
         filtered_results = {}
         for out_fname_base, grib_file in result.items():
             import glob
-            print(out_fname_base)
             full_grib_path = os.path.realpath(grib_file)
             temp_filter_folder = (
                 f"{os.path.dirname(full_grib_path)}/{out_fname_base}.filtered"
@@ -317,13 +315,11 @@ def result_to_netcdf_legacy_files(
             os.makedirs(temp_filter_folder, exist_ok=True)
             os.chdir(temp_filter_folder)
             os.system(
-                f"grib_filter {here}/filter_rules {full_grib_path} &&"
-                f"ls"
+                f"grib_filter {here}/filter_rules {full_grib_path}"
             )
             os.chdir(here)
             for filter_file in glob.glob(f"{temp_filter_folder}/*.grib*"):
-                print(filter_file)
-                filter_base = os.path.splitext(os.path.basename(filter_file))
+                filter_base = os.path.splitext(os.path.basename(filter_file))[0]
                 filtered_results[f"{out_fname_base}_{filter_base}"] = filter_file
         result = filtered_results
 

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -315,8 +315,9 @@ def result_to_netcdf_legacy_files(
             os.chdir(temp_filter_folder)
             os.system(
                 f"echo {filter_rules} > {out_fname_base}.filter_rules && "
-                f"grib_filter {out_fname_base}.filter_rules {full_grib_path};"
-                f"rm {out_fname_base}.filter_rules"
+                f"grib_filter {out_fname_base}.filter_rules {full_grib_path} &&"
+                f"rm {out_fname_base}.filter_rules &&"
+                f"ls"
             )
             os.chdir(here)
             for filter_file in glob.glob(f"{temp_filter_folder}/*.grib*"):

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -271,13 +271,13 @@ def result_to_netcdf_legacy_files(
 
     elif isinstance(result, list):
         # Ensure objects are same type (This may not be necessary, but it probably implies something is wrong)
-        results_types: list[type] = list(set([type(r) for r in result]))
-        result_type = results_types[0]
+        result_types: list[type] = list(set([type(r) for r in result]))
+        result_type = result_types[0]
         assert (
-            len(results_types) == 1
+            len(result_types) == 1
             and result_type == str
             and (result[0].endswith(".grib") or result[0].endswith(".grib2"))
-        ), f"The 'netcdf_legacy' format can only accept grib files as input. Types received: {results_types}"
+        ), f"The 'netcdf_legacy' format can only accept grib files as input. Types received: {result_types}"
 
         result = {
             os.path.splitext(os.path.basename(result))[0]: result for result in result
@@ -291,7 +291,7 @@ def result_to_netcdf_legacy_files(
             len(result_types) == 1
             and result_type == str
             and (result[0].endswith(".grib") or result[0].endswith(".grib2"))
-        ), f"The 'netcdf_legacy' format can only accept grib files as input. Types received: {results_types}"
+        ), f"The 'netcdf_legacy' format can only accept grib files as input. Types received: {result_types}"
 
     else:
         add_user_log_and_raise_error(
@@ -308,15 +308,14 @@ def result_to_netcdf_legacy_files(
         filtered_results = {}
         for out_fname_base, grib_file in result.items():
             import glob
+
             full_grib_path = os.path.realpath(grib_file)
             temp_filter_folder = (
                 f"{os.path.dirname(full_grib_path)}/{out_fname_base}.filtered"
             )
             os.makedirs(temp_filter_folder, exist_ok=True)
             os.chdir(temp_filter_folder)
-            os.system(
-                f"grib_filter {here}/filter_rules {full_grib_path}"
-            )
+            os.system(f"grib_filter {here}/filter_rules {full_grib_path}")
             os.chdir(here)
             for filter_file in glob.glob(f"{temp_filter_folder}/*.grib*"):
                 filter_base = os.path.splitext(os.path.basename(filter_file))[0]
@@ -336,7 +335,7 @@ def result_to_netcdf_legacy_files(
             "please download as GRIB and convert to netCDF locally.\n"
         )
         add_user_log_and_raise_error(message, context=context, thisError=RuntimeError)
-    
+
     return nc_files
 
 

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -323,6 +323,7 @@ def result_to_netcdf_legacy_files(
                 filtered_results[f"{out_fname_base}_{filter_base}"] = filter_file
         result = filtered_results
 
+    print(f"Grib files for conversion: {result}")
     nc_files = []
     for out_fname_base, grib_file in result.items():
         out_fname = f"{out_fname_base}.nc"

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -56,11 +56,7 @@ def convert_format(
     # Keywords specific to writing to the target format
     to_target_kwargs: dict[str, Any] = config.get(f"to_{target_format}_kwargs", {})
 
-    convertor: None | Callable = {
-        "netcdf": result_to_netcdf_files,
-        "netcdf_legacy": result_to_netcdf_legacy_files,
-        "grib": result_to_grib_files,
-    }.get(target_format, None)
+    convertor: None | Callable = CONVERTORS.get(target_format, None)
 
     if convertor is not None:
         return convertor(
@@ -337,6 +333,13 @@ def result_to_netcdf_legacy_files(
         add_user_log_and_raise_error(message, context=context, thisError=RuntimeError)
 
     return nc_files
+
+
+CONVERTORS: dict[str, Callable] = {
+    "netcdf": result_to_netcdf_files,
+    "netcdf_legacy": result_to_netcdf_legacy_files,
+    "grib": result_to_grib_files,
+}
 
 
 def unknown_filetype_to_grib_files(

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -303,9 +303,9 @@ def result_to_netcdf_legacy_files(
     if filter_rules:
         # Filter the grib files to netCDFable chunks (in replacement of split_on in legacy system)
         here = os.getcwd()
-        os.system(f"echo {filter_rules} > {here}/filter_rules")
-        print(here, filter_rules)
-        os.system(f"cat {here}/filter_rules")
+        with open(f"{here}/filter_rules", "w") as f:
+            f.write(filter_rules)
+        os.system(f"echo POTATO; cat {here}/filter_rules")
         filtered_results = {}
         for out_fname_base, grib_file in result.items():
             import glob

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -254,7 +254,8 @@ def result_to_netcdf_legacy_files(
     Converts to netCDF3 only.
     """
     context.add_user_visible_error(
-        "The 'netcdf_legacy' format is deprecated and no longer supported, please use 'netcdf' instead."
+        "The 'netcdf_legacy' format is deprecated and no longer supported. "
+        "Users are encouraged to update workflows to use the updated, and CF compliant, 'netcdf' option."
     )
     context.add_stdout(
         f"Converting result ({result}) to legacy netCDF files with grib_to_netcdf"

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -302,11 +302,14 @@ def result_to_netcdf_legacy_files(
 
     if filter_rules:
         # Filter the grib files to netCDFable chunks (in replacement of split_on in legacy system)
+        here = os.getcwd()
+        os.system(f"echo {filter_rules} > {here}/filter_rules")
+        print(filter_rules)
+        os.system(f"cat {here}/filter_rules")
         filtered_results = {}
         for out_fname_base, grib_file in result.items():
             import glob
 
-            here = os.getcwd()
             full_grib_path = os.path.realpath(grib_file)
             temp_filter_folder = (
                 f"{os.path.dirname(full_grib_path)}/{out_fname_base}.filtered"
@@ -314,9 +317,7 @@ def result_to_netcdf_legacy_files(
             os.makedirs(temp_filter_folder, exist_ok=True)
             os.chdir(temp_filter_folder)
             os.system(
-                f"echo {filter_rules} > {out_fname_base}.filter_rules && "
-                f"grib_filter {out_fname_base}.filter_rules {full_grib_path} &&"
-                f"rm {out_fname_base}.filter_rules &&"
+                f"grib_filter {here}/filter_rules {full_grib_path} &&"
                 f"ls"
             )
             os.chdir(here)

--- a/tests/test_30_convertors.py
+++ b/tests/test_30_convertors.py
@@ -129,6 +129,7 @@ def test_grib_to_netcdf():
 EXTENSION_MAPPING = {
     "grib": ".grib",
     "netcdf": ".nc",
+    "netcdf_legacy": ".nc",
 }
 
 
@@ -169,6 +170,24 @@ def test_convert_format_to_grib(url, target_format="grib"):
         # Can't convert from netcdf to grib yet, so ensure in extension is the same as input
         _, out_ext = os.path.splitext(converted_files[0])
         assert out_ext == ext
+
+
+def test_convert_format_to_netcdf_legacy(url=TEST_GRIB_FILE, target_format="netcdf_legacy"):
+    remote_file = requests.get(url)
+    _, ext = os.path.splitext(url)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        os.chdir(tmpdirname)
+        tmp_file = f"test.{ext}"
+        with open(tmp_file, "wb") as f:
+            f.write(remote_file.content)
+
+        converted_files = convertors.convert_format(
+            tmp_file, target_format=target_format
+        )
+        assert isinstance(converted_files, list)
+        assert len(converted_files) == 1
+        _, out_ext = os.path.splitext(converted_files[0])
+        assert out_ext == EXTENSION_MAPPING.get(target_format, f".{target_format}")
 
 
 def test_safely_rename_variable():

--- a/tests/test_30_convertors.py
+++ b/tests/test_30_convertors.py
@@ -172,7 +172,9 @@ def test_convert_format_to_grib(url, target_format="grib"):
         assert out_ext == ext
 
 
-def test_convert_format_to_netcdf_legacy(url=TEST_GRIB_FILE, target_format="netcdf_legacy"):
+def test_convert_format_to_netcdf_legacy(
+    url=TEST_GRIB_FILE, target_format="netcdf_legacy"
+):
     remote_file = requests.get(url)
     _, ext = os.path.splitext(url)
     with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
Provide an option to use the grib_to_netcdf convertor for users wishing to use the legacy convertor, whilst the more modern conversion is being fine-tuned.