### PR TITLE
Fix for kwargs handling in post_processors

### DIFF
--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -137,15 +137,22 @@ class AbstractCdsAdaptor(AbstractAdaptor):
     # and currently only implemented for retrieve methods
     def _pre_retrieve(self, request: Request, default_download_format="zip"):
         self.input_request = deepcopy(request)
+        self.context.add_stdout(f"Input request:\n{self.input_request}")
         self.receipt = request.pop("receipt", False)
 
         # Extract post-process steps from the request before mapping:
         self.post_process_steps = self.pp_mapping(request.pop("post_process", []))
+        self.context.add_stdout(
+            f"Post-process steps extracted from request:\n{self.post_process_steps}"
+        )
 
         self.mapped_request = self.apply_mapping(request)  # type: ignore
 
         self.download_format = self.mapped_request.pop(
             "download_format", default_download_format
+        )
+        self.context.add_stdout(
+            f"Request mapped to {self.collection_id} format:\n{self.mapped_request}"
         )
 
     def pp_mapping(self, in_pp_config: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -19,7 +19,6 @@ def _reorganise_open_dataset_and_to_netcdf_kwargs(
         **config.pop("format_conversion_kwargs", dict()),
         **config.pop("post_processing_kwargs", dict()),
     }
-    print("HELLO", post_processing_kwargs)
 
     to_netcdf_kwargs = {
         **post_processing_kwargs.pop("to_netcdf_kwargs", dict()),
@@ -40,7 +39,6 @@ def _reorganise_open_dataset_and_to_netcdf_kwargs(
             "to_netcdf_kwargs": to_netcdf_kwargs,
         }
     )
-    print("BYE", post_processing_kwargs)
     config.update({"post_processing_kwargs": post_processing_kwargs})
     return config
 

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -19,6 +19,7 @@ def _reorganise_open_dataset_and_to_netcdf_kwargs(
         **config.pop("format_conversion_kwargs", dict()),
         **config.pop("post_processing_kwargs", dict()),
     }
+    print("HELLO", post_processing_kwargs)
 
     to_netcdf_kwargs = {
         **post_processing_kwargs.pop("to_netcdf_kwargs", dict()),
@@ -39,6 +40,7 @@ def _reorganise_open_dataset_and_to_netcdf_kwargs(
             "to_netcdf_kwargs": to_netcdf_kwargs,
         }
     )
+    print("BYE", post_processing_kwargs)
     config.update({"post_processing_kwargs": post_processing_kwargs})
     return config
 

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -193,7 +193,6 @@ class AbstractCdsAdaptor(AbstractAdaptor):
                 from cads_adaptors.tools.convertors import (
                     open_result_as_xarray_dictionary,
                 )
-                post_processing_kwargs = self.config.get("post_processing_kwargs", {})
 
                 post_processing_kwargs = self.config.get("post_processing_kwargs", {})
 

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -180,7 +180,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
 
             method_name = pp_step["method"]
             # TODO: Add extra condition to limit pps from dataset configurations
-            if hasattr(self, method_name):
+            if not hasattr(self, method_name):
                 self.context.add_user_visible_error(
                     message=f"Post-processor method '{method_name}' not available for this dataset"
                 )

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -167,6 +167,9 @@ class AbstractCdsAdaptor(AbstractAdaptor):
     def post_process(self, result: Any) -> dict[str, Any]:
         """Perform post-process steps on the retrieved data."""
         for i, pp_step in enumerate(self.post_process_steps):
+            self.context.add_stdout(
+                f"Performing post-process step {i+1} of {len(self.post_process_steps)}"
+            )
             # TODO: pp_mapping should have ensured "method" is always present
 
             if "method" not in pp_step:

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -201,12 +201,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
                 result = open_result_as_xarray_dictionary(
                     result,
                     context=self.context,
-                    open_datasets_kwargs=post_processing_kwargs.get(
-                        "open_datasets_kwargs", {}
-                    ),
-                    post_open_kwargs=post_processing_kwargs.get(
-                        "post_open_datasets_kwargs", {}
-                    ),
+                    **post_processing_kwargs
                 )
 
             result = method(result, **pp_step)

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -137,12 +137,12 @@ class AbstractCdsAdaptor(AbstractAdaptor):
     # and currently only implemented for retrieve methods
     def _pre_retrieve(self, request: Request, default_download_format="zip"):
         self.input_request = deepcopy(request)
-        self.context.add_stdout(f"Input request:\n{self.input_request}")
+        self.context.debug(f"Input request:\n{self.input_request}")
         self.receipt = request.pop("receipt", False)
 
         # Extract post-process steps from the request before mapping:
         self.post_process_steps = self.pp_mapping(request.pop("post_process", []))
-        self.context.add_stdout(
+        self.context.debug(
             f"Post-process steps extracted from request:\n{self.post_process_steps}"
         )
 
@@ -151,8 +151,8 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         self.download_format = self.mapped_request.pop(
             "download_format", default_download_format
         )
-        self.context.add_stdout(
-            f"Request mapped to {self.collection_id} format:\n{self.mapped_request}"
+        self.context.debug(
+            f"Request mapped to (collection_id={self.collection_id}):\n{self.mapped_request}"
         )
 
     def pp_mapping(self, in_pp_config: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -168,7 +168,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         """Perform post-process steps on the retrieved data."""
         for i, pp_step in enumerate(self.post_process_steps):
             self.context.add_stdout(
-                f"Performing post-process step {i+1} of {len(self.post_process_steps)}"
+                f"Performing post-process step {i+1} of {len(self.post_process_steps)}: {pp_step}"
             )
             # TODO: pp_mapping should have ensured "method" is always present
 
@@ -195,8 +195,14 @@ class AbstractCdsAdaptor(AbstractAdaptor):
                 )
                 post_processing_kwargs = self.config.get("post_processing_kwargs", {})
 
-                open_datasets_kwargs = post_processing_kwargs.get("open_datasets_kwargs", {})
-                post_open_datasets_kwargs = post_processing_kwargs.get("post_open_datasets_kwargs", {})
+                post_processing_kwargs = self.config.get("post_processing_kwargs", {})
+
+                open_datasets_kwargs = post_processing_kwargs.get(
+                    "open_datasets_kwargs", {}
+                )
+                post_open_datasets_kwargs = post_processing_kwargs.get(
+                    "post_open_datasets_kwargs", {}
+                )
                 self.context.add_stdout(
                     f"Opening result: {result} as xarray dictionary with kwargs:\n"
                     f"open_dataset_kwargs: {open_datasets_kwargs}\n"

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -33,6 +33,9 @@ def _reorganise_open_dataset_and_to_netcdf_kwargs(
         if key in to_netcdf_kwargs:
             post_open_datasets_kwargs[key] = to_netcdf_kwargs.pop(key)
 
+    # A quick clean up of some previous bad decisions:
+    post_open_datasets_kwargs.update(post_processing_kwargs.pop("post_open_kwargs", {}))
+
     post_processing_kwargs.update(
         {
             "post_open_datasets_kwargs": post_open_datasets_kwargs,

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -178,7 +178,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
                 )
                 continue
 
-            method_name = pp_step["method"]
+            method_name = pp_step.pop("method")
             # TODO: Add extra condition to limit pps from dataset configurations
             if not hasattr(self, method_name):
                 self.context.add_user_visible_error(
@@ -195,7 +195,9 @@ class AbstractCdsAdaptor(AbstractAdaptor):
                 from cads_adaptors.tools.convertors import (
                     open_result_as_xarray_dictionary,
                 )
-
+                self.context.add_stdout(
+                    f"Opening result: {result} as xarray dictionary with kwargs:\n{post_processing_kwargs}"
+                )
                 result = open_result_as_xarray_dictionary(
                     result,
                     context=self.context,

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -33,9 +33,6 @@ def _reorganise_open_dataset_and_to_netcdf_kwargs(
         if key in to_netcdf_kwargs:
             post_open_datasets_kwargs[key] = to_netcdf_kwargs.pop(key)
 
-    # A quick clean up of some previous bad decisions:
-    post_open_datasets_kwargs.update(post_processing_kwargs.pop("post_open_kwargs", {}))
-
     post_processing_kwargs.update(
         {
             "post_open_datasets_kwargs": post_open_datasets_kwargs,
@@ -193,18 +190,23 @@ class AbstractCdsAdaptor(AbstractAdaptor):
             # post processing is done on xarray objects,
             # so on first pass we ensure result is opened as xarray
             if i == 0:
-                post_processing_kwargs = self.config.get("post_processing_kwargs", {})
-
                 from cads_adaptors.tools.convertors import (
                     open_result_as_xarray_dictionary,
                 )
+                post_processing_kwargs = self.config.get("post_processing_kwargs", {})
+
+                open_datasets_kwargs = post_processing_kwargs.get("open_datasets_kwargs", {})
+                post_open_datasets_kwargs = post_processing_kwargs.get("post_open_datasets_kwargs", {})
                 self.context.add_stdout(
-                    f"Opening result: {result} as xarray dictionary with kwargs:\n{post_processing_kwargs}"
+                    f"Opening result: {result} as xarray dictionary with kwargs:\n"
+                    f"open_dataset_kwargs: {open_datasets_kwargs}\n"
+                    f"post_open_datasets_kwargs: {post_open_datasets_kwargs}"
                 )
                 result = open_result_as_xarray_dictionary(
                     result,
                     context=self.context,
-                    **post_processing_kwargs
+                    open_datasets_kwargs=open_datasets_kwargs,
+                    post_open_datasets_kwargs=post_open_datasets_kwargs,
                 )
 
             result = method(result, **pp_step)

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -46,24 +46,11 @@ def convert_format(
 ) -> list[str]:
     target_format = adaptor_tools.handle_data_format(target_format)
     post_processing_kwargs = config.get("post_processing_kwargs", {})
-    # open_datasets_kwargs: dict[str, Any] = post_processing_kwargs.get(
-    #     "open_datasets_kwargs", {}
-    # )
-    # post_open_datasets_kwargs: dict[str, Any] = post_processing_kwargs.get(
-    #     "post_open_datasets_kwargs", {}
-    # )
-
-    # # Keywords specific to writing to the target format
-    # to_target_kwargs: dict[str, Any] = post_processing_kwargs.get(f"to_{target_format}_kwargs", {})
 
     convertor: None | Callable = CONVERTORS.get(target_format, None)
 
     if convertor is not None:
-        return convertor(
-            result,
-            context=context,
-            **post_processing_kwargs
-        )
+        return convertor(result, context=context, **post_processing_kwargs)
 
     else:
         message = (
@@ -246,7 +233,9 @@ def result_to_netcdf_legacy_files(
     Can only accept a grib file, or list/dict of grib files as input.
     Converts to netCDF3 only.
     """
-    command: str | list[str] = to_netcdf_legacy_kwargs.get("command", ["grib_to_netcdf", "-S", "param"])
+    command: str | list[str] = to_netcdf_legacy_kwargs.get(
+        "command", ["grib_to_netcdf", "-S", "param"]
+    )
     filter_rules: str | None = to_netcdf_legacy_kwargs.get("filter", None)
 
     context.add_user_visible_error(
@@ -414,7 +403,9 @@ def grib_to_netcdf_files(
         context.add_stderr(message=message)
         raise RuntimeError(message)
 
-    out_nc_files = xarray_dict_to_netcdf(datasets, context=context, to_netcdf_kwargs=to_netcdf_kwargs)
+    out_nc_files = xarray_dict_to_netcdf(
+        datasets, context=context, to_netcdf_kwargs=to_netcdf_kwargs
+    )
 
     return out_nc_files
 

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -246,6 +246,7 @@ def result_to_netcdf_legacy_files(
         f"Converting result ({result}) to legacy netCDF files with grib_to_netcdf.\n"
         f"filter_rules: {filter_rules}\n"
         f"command: {command}"
+        f"kwargs: {kwargs}"
     )
 
     # Check result is a single grib_file or a list/dict of grib_files

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -46,6 +46,9 @@ def convert_format(
 ) -> list[str]:
     target_format = adaptor_tools.handle_data_format(target_format)
     post_processing_kwargs = config.get("post_processing_kwargs", {})
+    context.add_stdout(
+        f"Converting result ({result}) to {target_format} with kwargs: {post_processing_kwargs}"
+    )
 
     convertor: None | Callable = CONVERTORS.get(target_format, None)
 

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -238,12 +238,14 @@ def result_to_netcdf_legacy_files(
     )
     filter_rules: str | None = to_netcdf_legacy_kwargs.get("filter", None)
 
-    context.add_user_visible_error(
+    context.add_user_visible_log(
         "The 'netcdf_legacy' format is deprecated and no longer supported. "
         "Users are encouraged to update workflows to use the updated, and CF compliant, 'netcdf' option."
     )
     context.add_stdout(
-        f"Converting result ({result}) to legacy netCDF files with grib_to_netcdf"
+        f"Converting result ({result}) to legacy netCDF files with grib_to_netcdf.\n"
+        f"filter_rules: {filter_rules}\n"
+        f"command: {command}"
     )
 
     # Check result is a single grib_file or a list/dict of grib_files

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -239,7 +239,7 @@ def result_to_netcdf_legacy_files(
     command: str | list[str] = to_netcdf_legacy_kwargs.get(
         "command", ["grib_to_netcdf", "-S", "param"]
     )
-    filter_rules: str | None = to_netcdf_legacy_kwargs.get("filter", None)
+    filter_rules: str | None = to_netcdf_legacy_kwargs.get("filter_rules", None)
 
     context.add_user_visible_log(
         "The 'netcdf_legacy' format is deprecated and no longer supported. "

--- a/cads_adaptors/tools/post_processors.py
+++ b/cads_adaptors/tools/post_processors.py
@@ -65,8 +65,8 @@ def daily_reduce(
     out_xarray_dict = {}
     for in_tag, in_dataset in in_xarray_dict.items():
         out_tag = f"{in_tag}_daily-{how}"
-        context.add_stdout(f"Daily reduction: {how} {kwargs}")
-        context.add_user_visible_log(f"Temporal reduction: {how} {kwargs}")
+        context.add_stdout(f"Daily reduction: {how} {kwargs}\n{in_dataset}")
+        context.add_user_visible_log(f"Daily reduction: {how} {kwargs}")
         reduced_data = temporal.daily_reduce(
             in_dataset,
             how=how,

--- a/environment.yml
+++ b/environment.yml
@@ -32,4 +32,4 @@ dependencies:
 - xarray
 - pip:
   - rooki
-  - earthkit-transforms>=0.3.0
+  - earthkit-transforms>=0.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ complete = [
   # Additional dependencies required by the worker image
   "aiohttp",
   "cacholote",
-  "cads-mars-server@git+https://github.com/ecmwf-projects/cads-mars-server.git",
+  "cads-mars-server@git+https://github.com/ecmwf-projects/cads-mars-server.git>=0.2.5",
   "cdsapi",
   "cfgrib>=0.9.13.0",
   "cftime",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ complete = [
   "cftime",
   "dask",
   "ecmwflibs",
-  "earthkit-transforms>=0.3.0",
+  "earthkit-transforms>=0.3.3",
   "fsspec",
   "h5netcdf",
   "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ complete = [
   # Additional dependencies required by the worker image
   "aiohttp",
   "cacholote",
-  "cads-mars-server@git+https://github.com/ecmwf-projects/cads-mars-server.git>=0.2.5",
+  "cads-mars-server@git+https://github.com/ecmwf-projects/cads-mars-server.git",
   "cdsapi",
   "cfgrib>=0.9.13.0",
   "cftime",


### PR DESCRIPTION
Consistant kwarg naming in methods to make it easier to parse through.
Explicit handling of to_{TARGET}_kwargs such that they are not conflated with other kwargs when called in different contexts (e.g. after post-processing).
