### PR TITLE
Fix the case when only an auxiliary variable is requested 

### DIFF
--- a/cads_adaptors/adaptors/cadsobs/adaptor.py
+++ b/cads_adaptors/adaptors/cadsobs/adaptor.py
@@ -96,7 +96,21 @@ class ObservationsAdaptor(AbstractCdsAdaptor):
                     )
                     requested_variables.remove(auxvar)
                     requested_metadata_fields.add(metadata_field)
-
+        # Check that there are no orphan auxiliary variables without its regular
+        # variable and if any, add the regular variable
+        inverse_aux_var_mapping = {
+            auxvar_dict["auxvar"]: regular_var
+            for regular_var, auxiliary_vars in aux_var_mapping.items()
+            for auxvar_dict in auxiliary_vars
+        }
+        for auxvar in auxiliary_variables:
+            regular_variable = inverse_aux_var_mapping[auxvar]
+            if regular_variable not in requested_variables:
+                self.context.warning(
+                    f"{auxvar} is auxiliary metadata of variable {regular_variable}, "
+                    f"adding ir to the request."
+                )
+                requested_variables.append(regular_variable)
         mapped_request["variables"] = requested_variables
         return requested_metadata_fields
 

--- a/tests/test_cadsobs_adaptor.py
+++ b/tests/test_cadsobs_adaptor.py
@@ -166,6 +166,11 @@ TEST_REQUEST = {
     "_timestamp": str(time.time()),
 }
 
+TEST_REQUEST_ORPHAN_AUXVAR = TEST_REQUEST.copy()
+TEST_REQUEST_ORPHAN_AUXVAR.update(
+    dict(variable=["maximum_air_temperature_negative_total_uncertainty"])
+)
+
 TEST_ADAPTOR_CONFIG = {
     "entry_point": "cads_adaptors:ObservationsAdaptor",
     "collection_id": "insitu-observations-near-surface-temperature-us-climate-reference-network",
@@ -208,7 +213,8 @@ TEST_ADAPTOR_CONFIG = {
 }
 
 
-def test_adaptor(tmp_path, monkeypatch):
+@pytest.mark.parametrize("test_request", [TEST_REQUEST, TEST_REQUEST_ORPHAN_AUXVAR])
+def test_adaptor(tmp_path, monkeypatch, test_request):
     monkeypatch.setattr(
         "cads_adaptors.adaptors.cadsobs.adaptor.CadsobsApiClient",
         MockerCadsobsApiClient,
@@ -218,7 +224,7 @@ def test_adaptor(tmp_path, monkeypatch):
     # is not needed for this test
 
     adaptor = ObservationsAdaptor(test_form, **TEST_ADAPTOR_CONFIG)
-    result = adaptor.retrieve(TEST_REQUEST)
+    result = adaptor.retrieve(test_request)
     tempfile = Path(tmp_path, "test_adaptor.nc")
     with tempfile.open("wb") as tmpf:
         tmpf.write(result.read())


### PR DESCRIPTION
Now the regular variable related to the auxiliary variable is added to the request. For example if only the "air_temperature total_uncertainty" is in the request the "air_temperature" is added.