### PR TITLE
WIP: Feature/user visible logs

### DIFF
--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -174,7 +174,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
 
             if "method" not in pp_step:
                 self.context.add_user_visible_log(
-                    "ERROR: Post-processor method not specified, skipping post-processing step: {pp_step}"
+                    f"ERROR: Post-processor method not specified, skipping post-processing step: {pp_step}"
                 )
                 continue
 

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -92,8 +92,6 @@ def execute_mars(
             f"Request submitted to the MARS server:\n{requests}\n"
             f"Full error message:\n{error_lines}\n"
         )
-        context.add_user_visible_error(message=error_message)
-
         error_message += f"Exception: {reply.error}\n"
         raise MarsRuntimeError(error_message)
 
@@ -101,9 +99,6 @@ def execute_mars(
         error_message = (
             "MARS returned no data, please check your selection."
             f"Request submitted to the MARS server:\n{requests}\n"
-        )
-        context.add_user_visible_error(
-            message=error_message,
         )
         raise MarsNoDataError(error_message)
 

--- a/cads_adaptors/constraints.py
+++ b/cads_adaptors/constraints.py
@@ -682,15 +682,16 @@ def legacy_intersect_constraints(
             requests.append(output_request)
 
     if len(requests) == 0:
-        context.add_user_visible_error(
-            "Your request has not produce a valid combination of values, please check your selection.\n"
-            "If using the cdsapi, please ensure that the values in your request match the values provided"
+        context.add_user_visible_log(
+            "ERROR: Your request has not produce a valid combination of values, please check your selection."
+            "\n If using the cdsapi, please ensure that the values in your request match the values provided"
             f" in the web-portal, your request:\n {request}\n"
             "If you believe this to be a data store error, please contact user support.\n"
         )
         raise RuntimeError(
             "Request has not produce a valid combination of values, please check your selection.\n"
             f"{request}"
+            "If you believe this to be a data store error, please contact user support.\n"
         )
 
     return requests

--- a/cads_adaptors/exceptions.py
+++ b/cads_adaptors/exceptions.py
@@ -66,3 +66,15 @@ class RoocsRuntimeError(RuntimeError):
 
 class RoocsValueError(ValueError):
     """Raised when a ROOCS request fails due to a value error."""
+
+
+class DownloadPreparationError(RuntimeError):
+    """Raised when a request fails during download preparation."""
+
+
+class PostProcessingError(RuntimeError):
+    """Raised when a request fails during post processing."""
+
+
+class FormatConversionError(RuntimeError):
+    """Raised when a request fails during a format conversion step."""

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -69,7 +69,7 @@ def result_to_grib_files(
         return unknown_filetype_to_grib_files(result, context=context, **kwargs)
     elif isinstance(result, xr.Dataset):
         context.add_user_visible_log(
-            "Cannot convert xarray.Dataset to grib, returning as netCDF. "
+            "ERROR: Cannot convert xarray.Dataset to grib, returning as netCDF. "
             "Please note that post-processing uses xarray.Datasets. "
         )
         return xarray_dict_to_netcdf({"data": result}, context=context, **kwargs)

--- a/cads_adaptors/tools/post_processors.py
+++ b/cads_adaptors/tools/post_processors.py
@@ -47,8 +47,8 @@ def pp_config_mapping(
     while pp_config.get("method") in CONFIG_MAPPING and cnt < 100:
         pp_config = {**pp_config, **CONFIG_MAPPING[pp_config["method"]]}
     if "method" not in pp_config:
-        context.add_user_visible_error(
-            f"Ignoring invalid post-processor config: {pp_config}"
+        context.add_user_visible_log(
+            f"WARNING: Ignoring invalid post-processor config: {pp_config}"
         )
         return {}
     return pp_config

--- a/cads_adaptors/tools/post_processors.py
+++ b/cads_adaptors/tools/post_processors.py
@@ -65,8 +65,9 @@ def daily_reduce(
     out_xarray_dict = {}
     for in_tag, in_dataset in in_xarray_dict.items():
         out_tag = f"{in_tag}_daily-{how}"
-        context.add_stdout(f"Daily reduction: {how} {kwargs}\n{in_dataset}")
-        context.add_user_visible_log(f"Daily reduction: {how} {kwargs}")
+        context.add_user_visible_log(
+            f"Applying daily reduction to {in_tag}. Method={how}; Addtional kwargs: {kwargs}"
+        )
         reduced_data = temporal.daily_reduce(
             in_dataset,
             how=how,
@@ -91,8 +92,9 @@ def monthly_reduce(
     out_xarray_dict = {}
     for in_tag, in_dataset in in_xarray_dict.items():
         out_tag = f"{in_tag}_monthly-{how}"
-        context.add_stdout(f"Temporal reduction: {how} {kwargs}")
-        context.add_user_visible_log(f"Temporal reduction: {how} {kwargs}")
+        context.add_user_visible_log(
+            f"Applying monthly reduction to {in_tag}. Method={how}; Addtional kwargs: {kwargs}"
+        )
         reduced_data = temporal.monthly_reduce(
             in_dataset,
             how=how,

--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -65,14 +65,14 @@ def try_download(urls: List[str], context: Context, **kwargs) -> List[str]:
             paths.append(path)
 
     if len(paths) == 0:
-        context.add_user_visible_error(
+        context.add_stderr(
+            f"Request empty. No data found from the following URLs:"
+            f"\n{yaml.safe_dump(urls, indent=2)}"
+        )
+        raise UrlNoDataError(
             "Your request has not found any data, please check your selection.\n"
             "This may be due to temporary connectivity issues with the source data.\n"
             "If this problem persists, please contact user support."
-        )
-        raise UrlNoDataError(
-            f"Request empty. No data found from the following URLs:"
-            f"\n{yaml.safe_dump(urls, indent=2)} "
         )
     # TODO: raise a warning if len(paths)<len(urls). Need to check who sees this warning
     return paths

--- a/tests/test_30_area_selector.py
+++ b/tests/test_30_area_selector.py
@@ -5,6 +5,7 @@ import unittest
 import numpy as np
 import xarray as xr
 
+from cads_adaptors.exceptions import PostProcessingError
 from cads_adaptors.tools.area_selector import (
     area_selector,
     get_dim_slices,
@@ -82,7 +83,7 @@ class TestGetDimSlices(unittest.TestCase):
         self.assertEqual(result, [slice(300, 360), slice(0, 10)])
 
     def test_get_dim_slices_incompatible_area(self):
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(PostProcessingError):
             get_dim_slices(self.ds, "latitude", -100, -91)
 
     def test_get_dim_slices_descending(self):


### PR DESCRIPTION
User visible error messages were not implemented in the best way.

The error message in the raised exception is made visible to the user, therefore it is not required to repeat in a call to add_user_visible_error. In some cases this was causing error messages to be repeated in the logging.

Also, the log in add_user_visible_error is only returned to the user upon a raised exception, therefore is not useful for error messages which do not cause the request to raise, e.g. a user requesting an incompatible data_format. These have been changed to add_user_visible_log which are logged to the user by the cdsapi during runtime, with the level determined by the suffix of the message, in this case `ERROR`