### PR TITLE
Switch default ROOK_MODE to async

### DIFF
--- a/cads_adaptors/adaptors/roocs/__init__.py
+++ b/cads_adaptors/adaptors/roocs/__init__.py
@@ -7,6 +7,7 @@ from cads_adaptors.adaptors.cds import AbstractCdsAdaptor, Request
 from cads_adaptors.exceptions import RoocsRuntimeError, RoocsValueError
 
 ROOK_URL = "http://compute.mips.copernicus-climate.eu/wps"
+ROOK_MODE = "async"
 
 
 class RoocsCdsAdaptor(AbstractCdsAdaptor):
@@ -24,7 +25,7 @@ class RoocsCdsAdaptor(AbstractCdsAdaptor):
         os.environ["ROOK_URL"] = self.config.get("ROOK_URL", ROOK_URL)
 
         # switch off interactive logging to avoid threading issues
-        os.environ["ROOK_MODE"] = self.config.get("ROOK_MODE", "sync")
+        os.environ["ROOK_MODE"] = self.config.get("ROOK_MODE", ROOK_MODE)
 
         request = mapping.apply_mapping(request, self.mapping)
 


### PR DESCRIPTION
DKRZ have recommended switching the `ROOK_MODE` (the way in which we make requests to the ROOK WPS) from `sync` to `async`. This should result in more consistent results, as the `sync` mode seems to occasionally fail silently for large requests.