### PR TITLE
Do not attempt to apply area subsetting to xarray incompatible data

### DIFF
--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -140,7 +140,14 @@ def area_selector(
     # open object as earthkit data object
     ek_d = data.from_source("file", infile)
 
-    ds = ek_d.to_xarray(**to_xarray_kwargs)
+    try:
+        ds = ek_d.to_xarray(**to_xarray_kwargs)
+    except NotImplementedError:
+        context.logger.debug(
+            f"could not convert {ek_d.__class__.__name__} to xarray; "
+            "returning the original data"
+        )
+        return ds
 
     spatial_info = eka_tools.get_spatial_info(ds)
     lon_key = spatial_info["lon_key"]

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -217,5 +217,7 @@ def area_selector_paths(
                     ds_area.to_netcdf(out_fname)
                     out_paths.append(out_fname)
                 else:
-                    raise NotImplementedError(f"Output format not recognised {out_format}")
+                    raise NotImplementedError(
+                        f"Output format not recognised {out_format}"
+                    )
     return out_paths


### PR DESCRIPTION
When applying area selectors to data for which it is not possible to convert to xarray, simply return the original data rather than attempting (and failing) to convert it to xarray.