### PR TITLE
h5netcdf -> netcdf4 engine

### DIFF
--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -13,7 +13,7 @@ STANDARD_COMPRESSION_OPTIONS = {
         "zlib": True,
         "complevel": 1,
         "shuffle": True,
-        "engine": "h5netcdf",
+        "engine": "netcdf4",
     }
 }
 
@@ -431,7 +431,7 @@ def xarray_dict_to_netcdf(
     if isinstance(compression_options, str):
         compression_options = STANDARD_COMPRESSION_OPTIONS.get(compression_options, {})
 
-    to_netcdf_kwargs.setdefault("engine", compression_options.pop("engine", "h5netcdf"))
+    to_netcdf_kwargs.setdefault("engine", compression_options.pop("engine", "netcdf4"))
     out_nc_files = []
     for out_fname_base, dataset in datasets.items():
         to_netcdf_kwargs.update(


### PR DESCRIPTION
The h5netcdf engine produces netCDF files which are not compatible with GrADS (and older versions of CDO). This PR will address a number of the issues on the User Support Forum, See CUS-25905.

Also, the necdf4 engine produces nicer attributes in the file when printed with ncdump.

The compression options used are compatible with both netcdf4 and h5netcdf, so no compatibility issues.

The differences in performance between the two engines are negligible.
