### PR TITLE
Compute area before writing

### DIFF
--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -226,7 +226,7 @@ def area_selector_paths(
                         + ["nc"]
                     )
                     context.logger.debug(f"out_fname: {out_fname}")
-                    ds_area.to_netcdf(out_fname)
+                    ds_area.compute().to_netcdf(out_fname)
                     out_paths.append(out_fname)
                 else:
                     raise NotImplementedError(


### PR DESCRIPTION
This may help with the lost dask jobs when trying to write to netcdf, but hard to fully test as I only see this problem in production.

Currently trying to force the error on mini-cci stack so I can see if this makes a difference.

Also need to check for potential memory issues this may cause