### PR TITLE
Feature/costing with mapped requests

### DIFF
--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -79,16 +79,18 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         # Safety net, not all stacks have the latest version of the api:
         if "inputs" in request:
             request = request["inputs"]
+        mapped_request = self.apply_mapping(request)
+
         # "precise_size" is a new costing method that is more accurate than "size
         if "precise_size" in costing_config.get(cost_threshold, {}):
             costs["precise_size"] = costing.estimate_precise_size(
                 self.form,
-                request,
+                mapped_request,
                 self.constraints,
                 **costing_kwargs,
             )
         # size is a fast and rough estimate of the number of fields
-        costs["size"] = costing.estimate_number_of_fields(self.form, request)
+        costs["size"] = costing.estimate_number_of_fields(self.form, mapped_request)
         # Safety net for integration tests:
         costs["number_of_fields"] = costs["size"]
         return costs

--- a/cads_adaptors/costing.py
+++ b/cads_adaptors/costing.py
@@ -7,7 +7,6 @@ from . import constraints
 
 EXCLUDED_WIDGETS = [
     "GeographicExtentWidget",
-    "UnknownWidget",
 ]
 
 # TODO: Handle DateRangeWidget


### PR DESCRIPTION
This means that date ranges are expanded and users can't cheat the costs so easily

MARS time convention is not expanded, so this does not defend against that, but if that is added to the mapping then this will allow that