### PR TITLE
Introduce check_validity method

### DIFF
--- a/cads_adaptors/adaptors/__init__.py
+++ b/cads_adaptors/adaptors/__init__.py
@@ -228,6 +228,9 @@ class DummyAdaptor(AbstractAdaptor):
     def apply_constraints(self, request: Request) -> dict[str, Any]:
         return {}
 
+    def check_validity(self, request: Request) -> Request:
+        return request
+
     def estimate_costs(self, request: Request, **kwargs: Any) -> dict[str, int]:
         size = int(request.get("size", 0))
         time = int(request.get("time", 0.0))

--- a/cads_adaptors/adaptors/__init__.py
+++ b/cads_adaptors/adaptors/__init__.py
@@ -103,6 +103,27 @@ class AbstractAdaptor(abc.ABC):
         )
 
     @abc.abstractmethod
+    def check_validity(self, request: Request) -> Request:
+        """Check the validity of the request.
+
+        Parameters
+        ----------
+        request : Request
+            Incoming request.
+
+        Returns
+        -------
+        Request
+            Valid request.
+
+        Raises
+        ------
+        cads_adaptors.exceptions.InvalidRequest
+            If the request is invalid.
+        """
+        pass
+
+    @abc.abstractmethod
     def normalise_request(self, request: Request) -> Request:
         """Apply any normalisation to the request before validation.
 

--- a/cads_adaptors/adaptors/__init__.py
+++ b/cads_adaptors/adaptors/__init__.py
@@ -103,7 +103,7 @@ class AbstractAdaptor(abc.ABC):
         )
 
     @abc.abstractmethod
-    def check_validity(self, request: Request) -> Request:
+    def check_validity(self, request: Request) -> None:
         """Check the validity of the request.
 
         Parameters
@@ -113,8 +113,8 @@ class AbstractAdaptor(abc.ABC):
 
         Returns
         -------
-        Request
-            Valid request.
+        None
+            If the request is valid.
 
         Raises
         ------
@@ -228,8 +228,8 @@ class DummyAdaptor(AbstractAdaptor):
     def apply_constraints(self, request: Request) -> dict[str, Any]:
         return {}
 
-    def check_validity(self, request: Request) -> Request:
-        return request
+    def check_validity(self, request: Request) -> None:
+        return
 
     def estimate_costs(self, request: Request, **kwargs: Any) -> dict[str, int]:
         size = int(request.get("size", 0))

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -57,6 +57,9 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         result = self.retrieve_list_of_results(request)
         return self.make_download_object(result)
 
+    def check_validity(self, request: Request) -> Request:
+        return request
+
     def apply_constraints(self, request: Request) -> dict[str, Any]:
         return constraints.validate_constraints(self.form, request, self.constraints)
 

--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -57,8 +57,8 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         result = self.retrieve_list_of_results(request)
         return self.make_download_object(result)
 
-    def check_validity(self, request: Request) -> Request:
-        return request
+    def check_validity(self, request: Request) -> None:
+        return
 
     def apply_constraints(self, request: Request) -> dict[str, Any]:
         return constraints.validate_constraints(self.form, request, self.constraints)


### PR DESCRIPTION
Introduce the adaptor's method `check_validity`, which is intended to be called to check a request's validity.
It should return either `None` if the request is valid, or raise an `InvalidRequest` exception in case the request is not valid.

**Needed by**
- https://github.com/ecmwf-projects/cads-processing-api-service/pull/230