### PR TITLE
Obs adaptor: args was missing a star expansion

### DIFF
--- a/cads_adaptors/adaptors/cadsobs/adaptor.py
+++ b/cads_adaptors/adaptors/cadsobs/adaptor.py
@@ -8,8 +8,8 @@ from cads_adaptors.exceptions import CadsObsRuntimeError, InvalidRequest
 
 
 class ObservationsAdaptor(AbstractCdsAdaptor):
-    def __init__(self, args, **kwargs):
-        super().__init__(args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.download_format = "as_source"
 
     def retrieve(self, request):

--- a/tests/test_cadsobs_adaptor.py
+++ b/tests/test_cadsobs_adaptor.py
@@ -210,7 +210,7 @@ def test_adaptor(tmp_path, monkeypatch):
     )
     test_form = {}
 
-    adaptor = ObservationsAdaptor(test_form, **TEST_ADAPTOR_CONFIG)
+    adaptor = ObservationsAdaptor(form=test_form, **TEST_ADAPTOR_CONFIG)
     result = adaptor.retrieve(TEST_REQUEST)
     tempfile = Path(tmp_path, "test_adaptor.nc")
     with tempfile.open("wb") as tmpf:
@@ -227,7 +227,7 @@ def test_adaptor_csv(tmp_path, monkeypatch):
     )
     test_form = {}
 
-    adaptor = ObservationsAdaptor(test_form, **TEST_ADAPTOR_CONFIG)
+    adaptor = ObservationsAdaptor(form=test_form, **TEST_ADAPTOR_CONFIG)
     test_request_csv = TEST_REQUEST.copy()
     test_request_csv["format"] = "csv"
     result = adaptor.retrieve(test_request_csv)
@@ -245,7 +245,7 @@ def test_adaptor_error(tmp_path, monkeypatch):
     )
     test_form = {}
 
-    adaptor = ObservationsAdaptor(test_form, **TEST_ADAPTOR_CONFIG)
+    adaptor = ObservationsAdaptor(form=test_form, **TEST_ADAPTOR_CONFIG)
     adaptor.context.add_user_visible_error = Mock()
     with pytest.raises(RuntimeError) as e:
         adaptor.retrieve(TEST_REQUEST)
@@ -262,7 +262,7 @@ def test_adaptor_wrong_key(monkeypatch):
     test_form = {}
     test_request = TEST_REQUEST.copy()
     test_request.pop("time_aggregation")
-    adaptor = ObservationsAdaptor(test_form, **TEST_ADAPTOR_CONFIG)
+    adaptor = ObservationsAdaptor(form=test_form, **TEST_ADAPTOR_CONFIG)
     with pytest.raises(InvalidRequest):
         adaptor.retrieve(test_request)
 
@@ -279,20 +279,20 @@ def test_adaptor_wrong_value(monkeypatch):
     test_form = {}
     test_request = TEST_REQUEST.copy()
     test_request["variable"] = "FAKE_VARIABLE"
-    adaptor = ObservationsAdaptor(test_form, **TEST_ADAPTOR_CONFIG)
+    adaptor = ObservationsAdaptor(form=test_form, **TEST_ADAPTOR_CONFIG)
     with pytest.raises(InvalidRequest):
         adaptor.retrieve(test_request)
 
     # And dataset_source variables
     test_request["time_aggregation"] = "FAKE_VARIABLE"
-    adaptor = ObservationsAdaptor(test_form, **TEST_ADAPTOR_CONFIG)
+    adaptor = ObservationsAdaptor(form=test_form, **TEST_ADAPTOR_CONFIG)
     with pytest.raises(InvalidRequest):
         adaptor.retrieve(test_request)
 
 
 def test_connection_error(tmp_path):
     test_form = {}
-    adaptor = ObservationsAdaptor(test_form, **TEST_ADAPTOR_CONFIG)
+    adaptor = ObservationsAdaptor(form=test_form, **TEST_ADAPTOR_CONFIG)
     adaptor.context.add_user_visible_error = Mock()
     with pytest.raises(CadsObsConnectionError) as e:
         adaptor.retrieve(TEST_REQUEST)
@@ -303,7 +303,7 @@ def test_connection_error(tmp_path):
 
 def test_api_error(tmp_path, monkeypatch):
     test_form = {}
-    adaptor = ObservationsAdaptor(test_form, **TEST_ADAPTOR_CONFIG)
+    adaptor = ObservationsAdaptor(form=test_form, **TEST_ADAPTOR_CONFIG)
     monkeypatch.setattr(
         "cads_adaptors.adaptors.cadsobs.adaptor.CadsobsApiClient",
         BackendErrorCadsobsApiClient,


### PR DESCRIPTION
In the test forms was passed as a positional argument but in the worker is passed as a keyword argument. This make it fais with missing argument. The test uses now a keyword argument too so it does the same the worker does.