### PR TITLE
Reduce std output messages

### DIFF
--- a/cads_adaptors/adaptors/cds.py
+++ b/cads_adaptors/adaptors/cds.py
@@ -243,7 +243,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
         #  it is the only one. Adaptors should be updated to use self.mapped_requests instead.
         self.mapped_request = self.mapped_requests[0]
 
-        self.context.add_stdout(
+        self.context.info(
             f"Request mapped to (collection_id={self.collection_id}):\n{self.mapped_requests}"
         )
 
@@ -298,7 +298,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
     def post_process(self, result: Any) -> dict[str, Any]:
         """Perform post-process steps on the retrieved data."""
         for i, pp_step in enumerate(self.pp_mapping(self.post_process_steps)):
-            self.context.add_stdout(
+            self.context.info(
                 f"Performing post-process step {i+1} of {len(self.post_process_steps)}: {pp_step}"
             )
             # TODO: pp_mapping should have ensured "method" is always present
@@ -333,7 +333,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
                 post_open_datasets_kwargs = post_processing_kwargs.get(
                     "post_open_datasets_kwargs", {}
                 )
-                self.context.add_stdout(
+                self.context.debug(
                     f"Opening result: {result} as xarray dictionary with kwargs:\n"
                     f"open_dataset_kwargs: {open_datasets_kwargs}\n"
                     f"post_open_datasets_kwargs: {post_open_datasets_kwargs}"
@@ -380,7 +380,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
             kwargs.setdefault(
                 "receipt", self.make_receipt(filenames=filenames, **receipt_kwargs)
             )
-        self.context.add_stdout(
+        self.context.debug(
             f"Creating download object as {download_format} with paths:\n{paths}\n and kwargs:\n{kwargs}"
         )
         # self.context.add_user_visible_log(
@@ -398,7 +398,7 @@ class AbstractCdsAdaptor(AbstractAdaptor):
                     "\n -".join(filenames)
                 )
             )
-            self.context.add_stderr(
+            self.context.error(
                 f"Error whilst preparing download object: {err}\n"
                 f"Paths: {paths}\n"
                 f"Download format: {download_format}\n"

--- a/cads_adaptors/adaptors/mars.py
+++ b/cads_adaptors/adaptors/mars.py
@@ -86,10 +86,10 @@ def execute_mars(
     }
     env["username"] = str(env["namespace"]) + ":" + str(env["user_id"]).split("-")[-1]
 
-    context.add_stdout(f"Request sent to proxy MARS client: {requests}")
+    context.info(f"Request sent to proxy MARS client: {requests}")
     reply = cluster.execute(requests, env, target)
     reply_message = str(reply.message)
-    context.add_stdout(message=reply_message)
+    context.debug(message=reply_message)
 
     if reply.error:
         error_lines = "\n".join(

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -171,9 +171,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
         #   be useful to reduce the repetitive config in each sub-adaptor of adaptor.json
 
         # self.mapped_requests contains the schema-checked, intersected and (top-level mapping) mapped request
-        self.context.info(
-            f"MultiMarsCdsAdaptor, full_request: {self.mapped_requests}"
-        )
+        self.context.info(f"MultiMarsCdsAdaptor, full_request: {self.mapped_requests}")
 
         # We now split the mapped_request into sub-adaptors
         mapped_requests = []
@@ -193,9 +191,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
                         mapping.apply_mapping(this_request, this_adaptor.mapping)
                     )
 
-        self.context.info(
-            f"MultiMarsCdsAdaptor, mapped_requests: {mapped_requests}"
-        )
+        self.context.info(f"MultiMarsCdsAdaptor, mapped_requests: {mapped_requests}")
         result = execute_mars(
             mapped_requests,
             context=self.context,

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -65,7 +65,7 @@ class MultiAdaptor(AbstractCdsAdaptor):
             this_request = self.split_request(
                 request, this_values, **this_adaptor.config
             )
-            self.context.add_stdout(
+            self.context.debug(
                 f"MultiAdaptor, {adaptor_tag}, this_request: {this_request}"
             )
 
@@ -73,8 +73,9 @@ class MultiAdaptor(AbstractCdsAdaptor):
                 try:
                     this_request = this_adaptor.normalise_request(this_request)
                 except Exception:
-                    self.context.add_stdout(
-                        f"MultiAdaptor, {adaptor_tag}, this_request: {this_request}"
+                    self.context.warning(
+                        f"MultiAdaptor failed to normalise request.\n"
+                        f"adaptor_tag: {adaptor_tag}\nthis_request: {this_request}"
                     )
                 sub_adaptors[adaptor_tag] = (this_adaptor, this_request)
 
@@ -101,7 +102,7 @@ class MultiAdaptor(AbstractCdsAdaptor):
             )
         self.mapped_request = self.mapped_requests[0]
 
-        self.context.add_stdout(f"MultiAdaptor, full_request: {self.mapped_request}")
+        self.context.debug(f"MultiAdaptor, full_request: {self.mapped_request}")
 
         sub_adaptors = self.split_adaptors(self.mapped_request)
 
@@ -121,7 +122,7 @@ class MultiAdaptor(AbstractCdsAdaptor):
                 f"{exception_logs}"
             )
 
-        self.context.add_stdout(f"MultiAdaptor, result paths:\n{paths}")
+        self.context.debug(f"MultiAdaptor, result paths:\n{paths}")
 
         return paths
 
@@ -170,7 +171,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
         #   be useful to reduce the repetitive config in each sub-adaptor of adaptor.json
 
         # self.mapped_requests contains the schema-checked, intersected and (top-level mapping) mapped request
-        self.context.add_stdout(
+        self.context.info(
             f"MultiMarsCdsAdaptor, full_request: {self.mapped_requests}"
         )
 
@@ -183,7 +184,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
                 this_request = self.split_request(
                     mapped_request_piece, this_values, **this_adaptor.config
                 )
-                self.context.add_stdout(
+                self.context.info(
                     f"MultiMarsCdsAdaptor, {adaptor_tag}, this_request: {this_request}"
                 )
 
@@ -192,7 +193,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
                         mapping.apply_mapping(this_request, this_adaptor.mapping)
                     )
 
-        self.context.add_stdout(
+        self.context.info(
             f"MultiMarsCdsAdaptor, mapped_requests: {mapped_requests}"
         )
         result = execute_mars(

--- a/cads_adaptors/adaptors/roocs/__init__.py
+++ b/cads_adaptors/adaptors/roocs/__init__.py
@@ -47,7 +47,7 @@ class RoocsCdsAdaptor(AbstractCdsAdaptor):
             raise RoocsRuntimeError(response.status)
         urls += [response.provenance(), response.provenance_image()]
 
-        self.context.add_stdout(f"DOWNLOAD KWARGS: {download_kwargs}")
+        self.context.debug(f"DOWNLOAD KWARGS: {download_kwargs}")
         paths = url_tools.try_download(urls, context=self.context, **download_kwargs)
 
         return download_tools.DOWNLOAD_FORMATS["zip"](paths)

--- a/cads_adaptors/tools/general.py
+++ b/cads_adaptors/tools/general.py
@@ -42,7 +42,7 @@ def split_requests_on_keys(
         if not mapping_options.get("wants_dates", False):
             split_by_month = False
             if context:
-                context.add_stderr(
+                context.error(
                     "For the time being, split-by-month is only supported for wants_dates=True!"
                 )
 

--- a/cads_adaptors/tools/post_processors.py
+++ b/cads_adaptors/tools/post_processors.py
@@ -77,8 +77,7 @@ def daily_reduce(
     out_xarray_dict = {}
     for in_tag, in_dataset in in_xarray_dict.items():
         out_tag = f"{in_tag}_daily-{how}"
-        context.add_stdout(f"Daily reduction: {how} {kwargs}\n{in_dataset}")
-        context.add_user_visible_log(f"Daily reduction: {how} {kwargs}")
+        context.debug(f"Daily reduction: {how} {kwargs}\n{in_dataset}")
         reduced_data = temporal.daily_reduce(
             in_dataset,
             how=how,
@@ -103,8 +102,7 @@ def monthly_reduce(
     out_xarray_dict = {}
     for in_tag, in_dataset in in_xarray_dict.items():
         out_tag = f"{in_tag}_monthly-{how}"
-        context.add_stdout(f"Temporal reduction: {how} {kwargs}")
-        context.add_user_visible_log(f"Temporal reduction: {how} {kwargs}")
+        context.debug(f"Temporal reduction: {how} {kwargs}")
         reduced_data = temporal.monthly_reduce(
             in_dataset,
             how=how,
@@ -127,7 +125,7 @@ def update_history(
     elif isinstance(history, str):
         history += f"\n{update_text}"
     else:
-        context.add_stderr(
+        context.error(
             f"Unexpected history attribute type in existing xarray: {type(history)}"
         )
         return dataset

--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -57,7 +57,7 @@ def try_download(
         if dir:
             os.makedirs(dir, exist_ok=True)
         try:
-            context.add_stdout(f"Downloading {url} to {path}")
+            context.debug(f"Downloading {url} to {path}")
             multiurl.download(
                 url,
                 path,
@@ -78,9 +78,9 @@ def try_download(
                     f"\n{yaml.safe_dump(url, indent=2)} "
                 )
             else:
-                context.add_stdout(f"Failed download for URL: {url}\nException: {e}")
+                context.debug(f"Failed download for URL: {url}\nException: {e}")
         except Exception as e:
-            context.add_stdout(f"Failed download for URL: {url}\nException: {e}")
+            context.debug(f"Failed download for URL: {url}\nException: {e}")
         else:
             paths.append(path)
 


### PR DESCRIPTION
Reduce standard output events by using debug for a number of messages currently being printed.

Also changed from `add_stdout` -> `info` and `add_stderr` -> `error` for consistency in the syntax used.