### PR TITLE
Feature/multi adaptor filter keys

### DIFF
--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -24,7 +24,8 @@ class MultiAdaptor(AbstractCdsAdaptor):
         """
         required_keys = ensure_list(required_keys)
         this_request = {}
-        # loop over keys in the full_request
+        # loop over keys to be filtered, we default to all keys until datasets have been updated
+        #  the filter_keys will possibly make dont_split_keys redundant, but keep both for now
         if filter_keys is None:
             filter_keys = list(full_request.keys())
         for key in filter_keys:

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -24,15 +24,13 @@ class MultiAdaptor(AbstractCdsAdaptor):
         """
         required_keys = ensure_list(required_keys)
         this_request = {}
-        # loop over keys to be filtered, we default to all keys until datasets have been updated
-        #  the filter_keys will possibly make dont_split_keys redundant, but keep both for now
+        # Default filter_keys to all keys
         if filter_keys is None:
             filter_keys = list(full_request.keys())
-        for key in filter_keys:
-            # get the values for this key
-            req_vals = full_request.get(key, [])
-            # If dont_split_key, then copy the key and values to the new request
-            if key in ensure_list(dont_split_keys):
+        for key, req_vals in full_request.items():
+            # If not in filter_keys or is in dont_split_key, then copy the key and values to the new request
+            #  filter_keys may make dont_split_keys redundant, but keep both for now
+            if key not in filter_keys or key in ensure_list(dont_split_keys):
                 this_request[key] = req_vals
             else:
                 # filter for values relevant to this_adaptor:

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -189,14 +189,13 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
                 this_request = self.split_request(
                     mapped_request_piece, this_values, **this_adaptor.config
                 )
-                self.context.add_stdout(
-                    f"MultiMarsCdsAdaptor, {adaptor_tag}, this_request: {this_request}"
-                )
-
                 if len(this_request) > 0:
                     mapped_requests.append(
                         mapping.apply_mapping(this_request, this_adaptor.mapping)
                     )
+            self.context.add_stdout(
+                f"MultiMarsCdsAdaptor, {adaptor_tag}, this_request: {this_request}"
+            )
 
         self.context.add_stdout(
             f"MultiMarsCdsAdaptor, mapped_requests: {mapped_requests}"

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -202,7 +202,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
         #   be useful to reduce the repetitive config in each sub-adaptor of adaptor.json
 
         # self.mapped_requests contains the schema-checked, intersected and (top-level mapping) mapped request
-        self.context.info(f"MultiMarsCdsAdaptor, full_request: {self.mapped_requests}")
+        self.context.debug(f"MultiMarsCdsAdaptor, mapped full request: {self.mapped_requests}")
 
         # We now split the mapped_request into sub-adaptors
         mapped_requests = []
@@ -231,11 +231,11 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
                         mapping.apply_mapping(this_request, this_adaptor.mapping)
                     )
 
-            self.context.info(
+            self.context.debug(
                 f"MultiMarsCdsAdaptor, {adaptor_tag}, this_request: {this_request}"
             )
 
-        self.context.info(f"MultiMarsCdsAdaptor, mapped_requests: {mapped_requests}")
+        self.context.debug(f"MultiMarsCdsAdaptor, mapped and split requests: {mapped_requests}")
         result = execute_mars(
             mapped_requests,
             context=self.context,

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -13,6 +13,7 @@ class MultiAdaptor(AbstractCdsAdaptor):
         full_request: Request,  # User request
         this_values: dict[str, Any],  # key: [values] for the adaptor component
         dont_split_keys: list[str] = ["area", "grid"],
+        filter_keys: None | list[str] = None,
         required_keys: list[str] = [],
         **config: Any,
     ) -> Request:
@@ -24,7 +25,11 @@ class MultiAdaptor(AbstractCdsAdaptor):
         required_keys = ensure_list(required_keys)
         this_request = {}
         # loop over keys in the full_request
-        for key, req_vals in full_request.items():
+        if filter_keys is None:
+            filter_keys = list(full_request.keys())
+        for key in filter_keys:
+            # get the values for this key
+            req_vals = full_request.get(key, [])
             # If dont_split_key, then copy the key and values to the new request
             if key in ensure_list(dont_split_keys):
                 this_request[key] = req_vals

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -202,7 +202,9 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
         #   be useful to reduce the repetitive config in each sub-adaptor of adaptor.json
 
         # self.mapped_requests contains the schema-checked, intersected and (top-level mapping) mapped request
-        self.context.debug(f"MultiMarsCdsAdaptor, mapped full request: {self.mapped_requests}")
+        self.context.debug(
+            f"MultiMarsCdsAdaptor, mapped full request: {self.mapped_requests}"
+        )
 
         # We now split the mapped_request into sub-adaptors
         mapped_requests = []
@@ -235,7 +237,9 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
                 f"MultiMarsCdsAdaptor, {adaptor_tag}, this_request: {this_request}"
             )
 
-        self.context.debug(f"MultiMarsCdsAdaptor, mapped and split requests: {mapped_requests}")
+        self.context.debug(
+            f"MultiMarsCdsAdaptor, mapped and split requests: {mapped_requests}"
+        )
         result = execute_mars(
             mapped_requests,
             context=self.context,

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from cads_adaptors import AbstractCdsAdaptor, mapping
 from cads_adaptors.adaptors import Request
-from cads_adaptors.exceptions import MultiAdaptorNoDataError, CdsConfigurationError
+from cads_adaptors.exceptions import CdsConfigurationError, MultiAdaptorNoDataError
 from cads_adaptors.tools import adaptor_tools
 from cads_adaptors.tools.general import ensure_list
 
@@ -41,7 +41,9 @@ class MultiAdaptor(AbstractCdsAdaptor):
 
             # k in both this_adaptor_config and extract_subrequest_kwargs, check they are same type
             try:
-                assert isinstance(this_adaptor_config[k], type(extract_subrequest_kwargs[k]))
+                assert isinstance(
+                    this_adaptor_config[k], type(extract_subrequest_kwargs[k])
+                )
             except AssertionError:
                 raise CdsConfigurationError(
                     f"Adaptor configuration error: extract_subrequest_kwargs: {k} "
@@ -56,7 +58,9 @@ class MultiAdaptor(AbstractCdsAdaptor):
                 }
             elif isinstance(this_adaptor_config[k], list):
                 extract_subrequest_kwargs[k] = extract_subrequest_kwargs[k] + [
-                    val for val in this_adaptor_config[k] if val not in extract_subrequest_kwargs[k]
+                    val
+                    for val in this_adaptor_config[k]
+                    if val not in extract_subrequest_kwargs[k]
                 ]
             else:
                 extract_subrequest_kwargs[k] = this_adaptor_config[k]
@@ -123,7 +127,9 @@ class MultiAdaptor(AbstractCdsAdaptor):
             )
             this_values = adaptor_desc.get("values", {})
 
-            extract_subrequest_kwargs = self.get_extract_subrequest_kwargs(this_adaptor.config)
+            extract_subrequest_kwargs = self.get_extract_subrequest_kwargs(
+                this_adaptor.config
+            )
             this_request = self.extract_subrequest(
                 request, this_values, **extract_subrequest_kwargs
             )
@@ -242,7 +248,9 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
         for adaptor_tag, adaptor_desc in self.config["adaptors"].items():
             this_adaptor = adaptor_tools.get_adaptor(adaptor_desc, self.form)
             this_values = adaptor_desc.get("values", {})
-            extract_subrequest_kwargs = self.get_extract_subrequest_kwargs(this_adaptor.config)
+            extract_subrequest_kwargs = self.get_extract_subrequest_kwargs(
+                this_adaptor.config
+            )
             for mapped_request_piece in self.mapped_requests:
                 this_request = self.extract_subrequest(
                     mapped_request_piece, this_values, **extract_subrequest_kwargs

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -64,7 +64,6 @@ class MultiAdaptor(AbstractCdsAdaptor):
             else:
                 extract_subrequest_kwargs[k] = this_adaptor_config[k]
 
-        print(extract_subrequest_kwargs)
         return extract_subrequest_kwargs
 
     @staticmethod

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -30,7 +30,9 @@ class MultiAdaptor(AbstractCdsAdaptor):
         for key, req_vals in full_request.items():
             # If not in filter_keys or is in dont_split_key, then copy the key and values to the new request
             #  filter_keys may make dont_split_keys redundant, but keep both for now
-            if key not in ensure_list(filter_keys) or key in ensure_list(dont_split_keys):
+            if key not in ensure_list(filter_keys) or key in ensure_list(
+                dont_split_keys
+            ):
                 this_request[key] = req_vals
             else:
                 # filter for values relevant to this_adaptor:

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -73,7 +73,7 @@ class MultiAdaptor(AbstractCdsAdaptor):
         from cads_adaptors.tools import adaptor_tools
 
         base_extract_subrequest_kwargs = {
-            k: self.config[k]
+            k: self.config["extract_subrequest_kwargs"][k]
             for k in self.extract_subrequest_kws
             if k in self.config.get("extract_subrequest_kwargs", {})
         }

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -30,7 +30,7 @@ class MultiAdaptor(AbstractCdsAdaptor):
         for key, req_vals in full_request.items():
             # If not in filter_keys or is in dont_split_key, then copy the key and values to the new request
             #  filter_keys may make dont_split_keys redundant, but keep both for now
-            if key not in filter_keys or key in ensure_list(dont_split_keys):
+            if key not in ensure_list(filter_keys) or key in ensure_list(dont_split_keys):
                 this_request[key] = req_vals
             else:
                 # filter for values relevant to this_adaptor:

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -30,7 +30,6 @@ class MultiAdaptor(AbstractCdsAdaptor):
             for k in self.extract_subrequest_kws
             if k in self.config.get("extract_subrequest_kwargs", {})
         }
-        print(extract_subrequest_kwargs)
 
         for k in self.extract_subrequest_kws:
             if k not in this_adaptor_config:

--- a/cads_adaptors/adaptors/multi.py
+++ b/cads_adaptors/adaptors/multi.py
@@ -209,7 +209,7 @@ class MultiMarsCdsAdaptor(MultiAdaptor):
         # We now split the mapped_request into sub-adaptors
         mapped_requests = []
         base_extract_subrequest_kwargs = {
-            k: self.config[k]
+            k: self.config["extract_subrequest_kwargs"][k]
             for k in self.extract_subrequest_kws
             if k in self.config.get("extract_subrequest_kwargs", {})
         }

--- a/tests/test_15_adaptor_multi.py
+++ b/tests/test_15_adaptor_multi.py
@@ -44,33 +44,33 @@ ADAPTOR_CONFIG = {
 }
 
 
-def test_multi_adaptor_split_requests():
+def test_multi_adaptor_extract_subrequests():
     multi_adaptor = multi.MultiAdaptor(FORM, **ADAPTOR_CONFIG)
 
-    split_mean = multi_adaptor.split_request(
+    split_mean = multi_adaptor.extract_subrequest(
         REQUEST, multi_adaptor.config["adaptors"]["mean"]["values"]
     )
     assert split_mean == ADAPTOR_CONFIG["adaptors"]["mean"]["values"]
 
-    split_max = multi_adaptor.split_request(
+    split_max = multi_adaptor.extract_subrequest(
         REQUEST, multi_adaptor.config["adaptors"]["max"]["values"]
     )
     assert split_max == ADAPTOR_CONFIG["adaptors"]["max"]["values"]
 
 
-def test_multi_adaptor_split_requests_required_keys():
+def test_multi_adaptor_extract_subrequests_required_keys():
     multi_adaptor = multi.MultiAdaptor(FORM, **ADAPTOR_CONFIG)
 
     request = REQUEST.copy()
     del request["level"]
-    split_mean_required_missing = multi_adaptor.split_request(
+    split_mean_required_missing = multi_adaptor.extract_subrequest(
         request,
         multi_adaptor.config["adaptors"]["mean"]["values"],
         required_keys=["level"],
     )
     assert split_mean_required_missing == dict()
 
-    split_max_required_present = multi_adaptor.split_request(
+    split_max_required_present = multi_adaptor.extract_subrequest(
         REQUEST,
         multi_adaptor.config["adaptors"]["max"]["values"],
         required_keys=["level"],
@@ -78,13 +78,13 @@ def test_multi_adaptor_split_requests_required_keys():
     assert split_max_required_present == ADAPTOR_CONFIG["adaptors"]["max"]["values"]
 
 
-def test_multi_adaptor_split_requests_dont_split_keys():
+def test_multi_adaptor_extract_subrequests_dont_split_keys():
     multi_adaptor = multi.MultiAdaptor(FORM, **ADAPTOR_CONFIG)
 
     request = REQUEST.copy()
     # dont_split_keys as list dtype
     request["dont_split"] = [1, 2, 3, 4]
-    split_mean_dont_split_area = multi_adaptor.split_request(
+    split_mean_dont_split_area = multi_adaptor.extract_subrequest(
         request,
         multi_adaptor.config["adaptors"]["mean"]["values"],
         dont_split_keys=["dont_split"],
@@ -93,7 +93,7 @@ def test_multi_adaptor_split_requests_dont_split_keys():
 
     # dont_split_keys as integer dtype
     request["dont_split"] = "1"
-    split_mean_dont_split = multi_adaptor.split_request(
+    split_mean_dont_split = multi_adaptor.extract_subrequest(
         request,
         multi_adaptor.config["adaptors"]["mean"]["values"],
         dont_split_keys=["dont_split"],
@@ -102,7 +102,7 @@ def test_multi_adaptor_split_requests_dont_split_keys():
 
     # dont_split_keys as integer dtype
     request["dont_split"] = 1
-    split_mean_dont_split = multi_adaptor.split_request(
+    split_mean_dont_split = multi_adaptor.extract_subrequest(
         request,
         multi_adaptor.config["adaptors"]["mean"]["values"],
         dont_split_keys=["dont_split"],
@@ -111,7 +111,7 @@ def test_multi_adaptor_split_requests_dont_split_keys():
 
     # dont_split_keys as float dtype
     request["dont_split"] = 1.0
-    split_mean_dont_split = multi_adaptor.split_request(
+    split_mean_dont_split = multi_adaptor.extract_subrequest(
         request,
         multi_adaptor.config["adaptors"]["mean"]["values"],
         dont_split_keys=["dont_split"],
@@ -120,7 +120,7 @@ def test_multi_adaptor_split_requests_dont_split_keys():
 
     # dont_split_keys as dict dtype
     request["dont_split"] = {"a": 1}
-    split_mean_dont_split = multi_adaptor.split_request(
+    split_mean_dont_split = multi_adaptor.extract_subrequest(
         request,
         multi_adaptor.config["adaptors"]["mean"]["values"],
         dont_split_keys=["dont_split"],
@@ -129,7 +129,7 @@ def test_multi_adaptor_split_requests_dont_split_keys():
 
     # Area is dont_split as default
     request["area"] = [1, 2, 3, 4]
-    split_max_split_area = multi_adaptor.split_request(
+    split_max_split_area = multi_adaptor.extract_subrequest(
         request,
         multi_adaptor.config["adaptors"]["max"]["values"],
     )
@@ -137,7 +137,7 @@ def test_multi_adaptor_split_requests_dont_split_keys():
     assert "area" in split_max_split_area
 
 
-def test_multi_adaptor_split_requests_filter_keys():
+def test_multi_adaptor_extract_subrequests_filter_keys():
     multi_adaptor = multi.MultiAdaptor(FORM, **ADAPTOR_CONFIG)
 
     request = {
@@ -150,7 +150,7 @@ def test_multi_adaptor_split_requests_filter_keys():
     }
 
     # Check that we only filter a certain key
-    filter_a = multi_adaptor.split_request(
+    filter_a = multi_adaptor.extract_subrequest(
         request,
         values,
         filter_keys=["a"],
@@ -158,7 +158,7 @@ def test_multi_adaptor_split_requests_filter_keys():
     assert filter_a == {"a": ["a1"], "b": ["b1", "b2"]}
 
     # Check that we default to filter all keys (duplicate of previous test)
-    filter_all = multi_adaptor.split_request(
+    filter_all = multi_adaptor.extract_subrequest(
         request,
         values,
         # filter_keys=["a"],

--- a/tests/test_15_adaptor_multi.py
+++ b/tests/test_15_adaptor_multi.py
@@ -137,6 +137,25 @@ def test_multi_adaptor_split_requests_dont_split_keys():
     assert "area" in split_max_split_area
 
 
+def test_multi_adaptor_split_requests_filter_keys():
+    multi_adaptor = multi.MultiAdaptor(FORM, **ADAPTOR_CONFIG)
+
+    request = {
+        "a": ["a1", "a2"],
+        "b": ["b1", "b2"],
+    }
+    values = {
+        "a": ["a1"],
+        "b": ["b2"],
+    }
+    # dont_split_keys as list dtype
+    filter_a = multi_adaptor.split_request(
+        request, values,
+        filter_keys=["a"],
+    )
+    assert filter_a == {"a": ["a1"], "b": ["b1", "b2"]}
+
+
 def test_multi_adaptor_split_adaptors():
     multi_adaptor = multi.MultiAdaptor(FORM, **ADAPTOR_CONFIG)
 

--- a/tests/test_15_adaptor_multi.py
+++ b/tests/test_15_adaptor_multi.py
@@ -139,9 +139,7 @@ def test_multi_adaptor_extract_subrequests_dont_split_keys():
 
 
 def test_multi_adaptor_extract_subrequests_filter_keys():
-    multi_adaptor = multi.MultiAdaptor(
-        FORM, **ADAPTOR_CONFIG
-    )
+    multi_adaptor = multi.MultiAdaptor(FORM, **ADAPTOR_CONFIG)
 
     request = {
         "a": ["a1", "a2"],
@@ -181,7 +179,10 @@ EXTRACT_SR_KWARGS_ADAPTOR_CONFIG = {
             "entry_point": "cads_adaptors:DummyCdsAdaptor",
             "values": {
                 "a": ["a1", "a2", "a3", "a4"],
-                "b": ["b1", "b2",],
+                "b": [
+                    "b1",
+                    "b2",
+                ],
                 "c": ["c1", "c2", "c3"],
                 "d": ["d1", "d2", "d3", "d4"],
             },
@@ -189,7 +190,11 @@ EXTRACT_SR_KWARGS_ADAPTOR_CONFIG = {
             # no longer required. For backwards compatibility we do not next inside extract_subrequest_kwargs
             "filter_keys": ["a"],
             "dont_split_keys": ["e"],
-            "required_keys": ["a", "b", "c"]  # Includes check that double definition does not break
+            "required_keys": [
+                "a",
+                "b",
+                "c",
+            ],  # Includes check that double definition does not break
         },
         "adaptor2": {
             "entry_point": "cads_adaptors:DummyCdsAdaptor",
@@ -200,21 +205,21 @@ EXTRACT_SR_KWARGS_ADAPTOR_CONFIG = {
             },
         },
     },
-     # These filter keys are used by all sub-adaptors. In practice gecko will
-     # detect requiements and populate this list automatically
+    # These filter keys are used by all sub-adaptors. In practice gecko will
+    # detect requiements and populate this list automatically
     "extract_subrequest_kwargs": {
         "filter_keys": ["b", "c", "d"],
         "dont_split_keys": ["f", "g", "h"],
-        "required_keys": ["a"]
+        "required_keys": ["a"],
     },
 }
 
-@pytest.mark.parametrize(
-    "entry_point", ["MultiAdaptor", "MultiMarsCdsAdaptor"]
-)
+
+@pytest.mark.parametrize("entry_point", ["MultiAdaptor", "MultiMarsCdsAdaptor"])
 def test_multi_adaptor_get_extract_subrequests_kwargs(entry_point):
     multi_adaptor = multi.MultiAdaptor(
-        EXTRACT_SR_KWARGS_FORM, **{**EXTRACT_SR_KWARGS_ADAPTOR_CONFIG, "entry_point": entry_point}
+        EXTRACT_SR_KWARGS_FORM,
+        **{**EXTRACT_SR_KWARGS_ADAPTOR_CONFIG, "entry_point": entry_point},
     )
     # Check that we filter expected keys
     adaptor1_kwargs = multi_adaptor.get_extract_subrequest_kwargs(

--- a/tests/test_15_adaptor_multi.py
+++ b/tests/test_15_adaptor_multi.py
@@ -148,12 +148,22 @@ def test_multi_adaptor_split_requests_filter_keys():
         "a": ["a1"],
         "b": ["b2"],
     }
-    # dont_split_keys as list dtype
+
+    # Check that we only filter a certain key
     filter_a = multi_adaptor.split_request(
-        request, values,
+        request,
+        values,
         filter_keys=["a"],
     )
     assert filter_a == {"a": ["a1"], "b": ["b1", "b2"]}
+
+    # Check that we default to filter all keys (duplicate of previous test)
+    filter_all = multi_adaptor.split_request(
+        request,
+        values,
+        # filter_keys=["a"],
+    )
+    assert filter_all == {"a": ["a1"], "b": ["b2"]}
 
 
 def test_multi_adaptor_split_adaptors():


### PR DESCRIPTION
Add an option to set the keys to filter on when splitting a request between sub-adaptors
Defaults to all keys in request if filter_keys not found in config, so change only activated when dataset config is updated using yet to be merged gecko branch.