### PR TITLE
261 area selector for url adaptor to accept kwargs

### DIFF
--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -52,7 +52,7 @@ class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
                 paths,
                 self.area,
                 self.context,
-                **self.config.get("area_selector_kwargs", {}),
+                **self.config.get("post_processing_kwargs", {}),
             )
 
         return paths

--- a/cads_adaptors/adaptors/url.py
+++ b/cads_adaptors/adaptors/url.py
@@ -48,6 +48,11 @@ class UrlCdsAdaptor(cds.AbstractCdsAdaptor):
         paths = url_tools.try_download(urls, context=self.context, **download_kwargs)
 
         if self.area is not None:
-            paths = area_selector.area_selector_paths(paths, self.area, self.context)
+            paths = area_selector.area_selector_paths(
+                paths,
+                self.area,
+                self.context,
+                **self.config.get("area_selector_kwargs", {}),
+            )
 
         return paths

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -242,8 +242,8 @@ def area_selector_path(
     if out_format in ["nc", "netcdf"]:
         for fname_tag, ds_area in ds_area_dict.items():
             out_path = f"{fname_tag}.nc"
-            for data_var in ds_area.data_vars:
-                ds_area[data_var].encoding.setdefault("_FillValue", None)
+            for var in ds_area.variables:
+                ds_area[var].encoding.setdefault("_FillValue", None)
             ds_area.compute().to_netcdf(out_path)
             out_paths.append(out_path)
     else:
@@ -252,8 +252,8 @@ def area_selector_path(
         )
         for fname_tag, ds_area in ds_area_dict.items():
             out_path = f"{fname_tag}.nc"
-            for data_var in ds_area.data_vars:
-                ds_area[data_var].encoding.setdefault("_FillValue", None)
+            for var in ds_area.variables:
+                ds_area[var].encoding.setdefault("_FillValue", None)
             ds_area.compute().to_netcdf(out_path)
             out_paths.append(out_path)
 

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -222,7 +222,7 @@ def area_selector_path(
             _open_dataset_kwargs.setdefault("chunks", -1)
     else:
         open_datasets_kwargs.setdefault("decode_times", False)
-        open_datasets_kwargs.setdefault("chunks", -1)
+        open_datasets_kwargs.setdefault("chunks", "auto")
 
     ds_dict = convertors.open_file_as_xarray_dictionary(
         infile,

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -133,8 +133,8 @@ def get_dim_slices(
 
 def area_selector(
     ds: xr.Dataset,
-    context: Context = Context(),
     area: list = [+90, -180, -90, +180],
+    context: Context = Context(),
     **_kwargs,
 ) -> xr.Dataset:
     north, east, south, west = area
@@ -232,7 +232,7 @@ def area_selector_path(
 
     ds_area_dict = {
         ".".join([fname_tag, "area-subset"] + [str(a) for a in area]): area_selector(
-            ds, area, context, **area_selector_kwargs
+            ds, area=area, context=context, **area_selector_kwargs
         )
         for fname_tag, ds in ds_dict.items()
     }

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -205,6 +205,8 @@ def area_selector_path(
     area: list,
     context: Context,
     out_format: str | None = None,
+    area_selector_kwargs: dict[str, Any] = {},
+    open_datasets_kwargs: list[dict[str, Any]] | dict[str, Any] = {},
     **kwargs,
 ):
     # Deduce input format from infile
@@ -213,26 +215,21 @@ def area_selector_path(
     if out_format is None:
         out_format = in_format
 
-    # Open dataset with any open_dataset_kwargs
-    open_dataset_kwargs: list[dict[str, Any]] | dict[str, Any] = kwargs.get(
-        "open_datasets_kwargs", {}
-    )
     # Set decode_times to False to avoid any unnecessary issues with decoding time coordinates
-    if isinstance(open_dataset_kwargs, list):
-        for open_dataset_kwarg in open_dataset_kwargs:
-            open_dataset_kwarg.setdefault("decode_times", False)
+    if isinstance(open_datasets_kwargs, list):
+        for open_dataset_kwargs in open_datasets_kwargs:
+            open_dataset_kwargs.setdefault("decode_times", False)
     else:
-        open_dataset_kwargs.setdefault("decode_times", False)
+        open_datasets_kwargs.setdefault("decode_times", False)
 
     ds_dict = convertors.open_file_as_xarray_dictionary(
         infile,
         **{
             **kwargs,
-            "open_dataset_kwargs": open_dataset_kwargs,
+            "open_datasets_kwargs": open_dataset_kwargs,
         },
     )
 
-    area_selector_kwargs = kwargs.get("area_selector_kwargs", {})
     ds_area_dict = {
         ".".join(fname_tag, +["area-subset"] + [str(a) for a in area]): area_selector(
             ds, area, context, **area_selector_kwargs

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -242,6 +242,8 @@ def area_selector_path(
     if out_format in ["nc", "netcdf"]:
         for fname_tag, ds_area in ds_area_dict.items():
             out_path = f"{fname_tag}.nc"
+            for data_var in ds_area.data_vars:
+                ds_area[data_var].encoding.setdefault("_FillValue", None)
             ds_area.compute().to_netcdf(out_path)
             out_paths.append(out_path)
     else:
@@ -250,6 +252,8 @@ def area_selector_path(
         )
         for fname_tag, ds_area in ds_area_dict.items():
             out_path = f"{fname_tag}.nc"
+            for data_var in ds_area.data_vars:
+                ds_area[data_var].encoding.setdefault("_FillValue", None)
             ds_area.compute().to_netcdf(out_path)
             out_paths.append(out_path)
 

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -149,8 +149,6 @@ def area_selector(
     lon_key = spatial_info["lon_key"]
     lat_key = spatial_info["lat_key"]
 
-    ds = ds.chunk({lat_key: 100, lon_key: 100})
-
     # Handle simple regular case:
     if spatial_info["regular"]:
         extra_kwargs = {k: kwargs.pop(k) for k in ["precision"] if k in kwargs}

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -136,13 +136,14 @@ def area_selector(
 ):
     north, east, south, west = area
 
+    # Get any area_selector_kwargs from adaptor config, take a copy as they will be updated here
+    area_selector_kwargs = deepcopy(kwargs.get("area_selector_kwargs", {}))
+
     # Open dataset with any open_dataset_kwargs
     open_dataset_kwargs = kwargs.get("open_dataset_kwargs", {})
     # Set decode_times to False to avoid any unnecessary issues with decoding time coordinates
     open_dataset_kwargs.setdefault("decode_times", False)
     ds = xr.open_dataset(infile, **open_dataset_kwargs)
-
-    area_selector_kwargs = kwargs.get("area_selector_kwargs", {})
 
     spatial_info = eka_tools.get_spatial_info(
         ds,
@@ -209,7 +210,11 @@ def area_selector(
 
 
 def area_selector_paths(
-    paths: list, area: list, context: Context, out_format: str = "netcdf", **kwargs
+    paths: list,
+    area: list,
+    context: Context,
+    out_format: str = "netcdf",
+    **kwargs,
 ):
     with dask.config.set(scheduler="threads"):
         # We try to select the area for all paths, if any fail we return the original paths

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -134,7 +134,7 @@ def get_dim_slices(
 def area_selector(
     ds: xr.Dataset,
     context: Context = Context(),
-    area: list = [-90, -180, -90, +180],
+    area: list = [+90, -180, -90, +180],
     **_kwargs,
 ) -> xr.Dataset:
     north, east, south, west = area
@@ -224,7 +224,6 @@ def area_selector_path(
     else:
         open_dataset_kwargs.setdefault("decode_times", False)
 
-    # ds = xr.open_dataset(infile, **open_dataset_kwargs)
     ds_dict = convertors.open_file_as_xarray_dictionary(
         infile,
         **{
@@ -236,7 +235,7 @@ def area_selector_path(
     area_selector_kwargs = kwargs.get("area_selector_kwargs", {})
     ds_area_dict = {
         ".".join(fname_tag, +["area-subset"] + [str(a) for a in area]): area_selector(
-            ds, context, area=area, **area_selector_kwargs
+            ds, area, context, **area_selector_kwargs
         )
         for fname_tag, ds in ds_dict.items()
     }
@@ -270,7 +269,7 @@ def area_selector_paths(
         out_paths = []
         for path in paths:
             try:
-                out_paths += area_selector_path(path, context, area=area, **kwargs)
+                out_paths += area_selector_path(path, area, context, **kwargs)
             except NotImplementedError:
                 context.logger.debug(
                     f"could not convert {path} to xarray; returning the original data"

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -149,6 +149,8 @@ def area_selector(
     lon_key = spatial_info["lon_key"]
     lat_key = spatial_info["lat_key"]
 
+    ds = ds.chunk({lat_key: 100, lon_key: 100})
+
     # Handle simple regular case:
     if spatial_info["regular"]:
         extra_kwargs = {k: kwargs.pop(k) for k in ["precision"] if k in kwargs}
@@ -219,10 +221,8 @@ def area_selector_path(
     if isinstance(open_datasets_kwargs, list):
         for _open_dataset_kwargs in open_datasets_kwargs:
             _open_dataset_kwargs.setdefault("decode_times", False)
-            _open_dataset_kwargs.setdefault("chunks", "auto")
     else:
         open_datasets_kwargs.setdefault("decode_times", False)
-        open_datasets_kwargs.setdefault("chunks", "auto")
 
     ds_dict = convertors.open_file_as_xarray_dictionary(
         infile,

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -231,7 +231,7 @@ def area_selector_path(
     )
 
     ds_area_dict = {
-        ".".join(fname_tag, +["area-subset"] + [str(a) for a in area]): area_selector(
+        ".".join([fname_tag, "area-subset"] + [str(a) for a in area]): area_selector(
             ds, area, context, **area_selector_kwargs
         )
         for fname_tag, ds in ds_dict.items()

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -178,7 +178,7 @@ def area_selector(
         for lon_slice in lon_slices:
             sub_selections.append(
                 ds.sel(
-                    **area_selector_kwargs,
+                    **area_selector_kwargs,  # Any remaining kwargs are used for selection
                     **{
                         spatial_info["lat_key"]: lat_slice,
                         spatial_info["lon_key"]: lon_slice,

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -238,19 +238,20 @@ def area_selector_path(
     }
 
     # TODO: Consider using the write to file methods in convertors sub-module
+    out_paths = []
     if out_format in ["nc", "netcdf"]:
-        out_paths = [
-            ds_area.compute().to_netcdf(f"{fname_tag}.nc")
-            for fname_tag, ds_area in ds_area_dict.items()
-        ]
+        for fname_tag, ds_area in ds_area_dict.items():
+            out_path = f"{fname_tag}.nc"
+            ds_area.compute().to_netcdf(out_path)
+            out_paths.append(out_path)
     else:
         context.add_user_visible_error(
             f"Cannot write area selected data to {out_format}, writing to netcdf."
         )
-        out_paths = [
-            ds_area.compute().to_netcdf(os.path.join(fname_tag, "nc"))
-            for fname_tag, ds_area in ds_area_dict.items()
-        ]
+        for fname_tag, ds_area in ds_area_dict.items():
+            out_path = f"{fname_tag}.nc"
+            ds_area.compute().to_netcdf(out_path)
+            out_paths.append(out_path)
 
     return out_paths
 

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -219,7 +219,7 @@ def area_selector_path(
     if isinstance(open_datasets_kwargs, list):
         for _open_dataset_kwargs in open_datasets_kwargs:
             _open_dataset_kwargs.setdefault("decode_times", False)
-            _open_dataset_kwargs.setdefault("chunks", -1)
+            _open_dataset_kwargs.setdefault("chunks", "auto")
     else:
         open_datasets_kwargs.setdefault("decode_times", False)
         open_datasets_kwargs.setdefault("chunks", "auto")

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -217,8 +217,8 @@ def area_selector_path(
 
     # Set decode_times to False to avoid any unnecessary issues with decoding time coordinates
     if isinstance(open_datasets_kwargs, list):
-        for open_dataset_kwargs in open_datasets_kwargs:
-            open_dataset_kwargs.setdefault("decode_times", False)
+        for _open_dataset_kwargs in open_datasets_kwargs:
+            _open_dataset_kwargs.setdefault("decode_times", False)
     else:
         open_datasets_kwargs.setdefault("decode_times", False)
 
@@ -226,7 +226,7 @@ def area_selector_path(
         infile,
         **{
             **kwargs,
-            "open_datasets_kwargs": open_dataset_kwargs,
+            "open_datasets_kwargs": open_datasets_kwargs,
         },
     )
 

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -161,7 +161,7 @@ def area_selector(
             0
         ]
 
-        context.debug(f"lat_slice: {lat_slice}\nlon_slices: {lon_slices}")
+        context.info(f"lat_slice: {lat_slice}\nlon_slices: {lon_slices}")
 
         sub_selections = []
         for lon_slice in lon_slices:
@@ -174,12 +174,12 @@ def area_selector(
                     },
                 )
             )
-        context.debug(f"selections: {sub_selections}")
+        context.info(f"selections: {sub_selections}")
 
         ds_area = xr.concat(
             sub_selections, dim=lon_key, data_vars="minimal", coords="minimal"
         )
-        context.debug(f"ds_area: {ds_area}")
+        context.info(f"ds_area: {ds_area}")
 
         # Ensure that there are no length zero dimensions
         for dim in [lat_key, lon_key]:
@@ -219,10 +219,10 @@ def area_selector_path(
     if isinstance(open_datasets_kwargs, list):
         for _open_dataset_kwargs in open_datasets_kwargs:
             _open_dataset_kwargs.setdefault("decode_times", False)
-            _open_dataset_kwargs.setdefault("chunks", {"lat": 10, "lon": 10, "latitude": 10, "longitude": 10})
+            _open_dataset_kwargs.setdefault("chunks", -1)
     else:
         open_datasets_kwargs.setdefault("decode_times", False)
-        open_datasets_kwargs.setdefault("chunks", {"lat": 10, "lon": 10, "latitude": 10, "longitude": 10})
+        open_datasets_kwargs.setdefault("chunks", -1)
 
     ds_dict = convertors.open_file_as_xarray_dictionary(
         infile,
@@ -231,6 +231,7 @@ def area_selector_path(
             "open_datasets_kwargs": open_datasets_kwargs,
         },
     )
+    print(ds_dict)
 
     ds_area_dict = {
         ".".join([fname_tag, "area-subset"] + [str(a) for a in area]): area_selector(

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -219,8 +219,10 @@ def area_selector_path(
     if isinstance(open_datasets_kwargs, list):
         for _open_dataset_kwargs in open_datasets_kwargs:
             _open_dataset_kwargs.setdefault("decode_times", False)
+            _open_dataset_kwargs.setdefault("chunks", {"lat": 10, "lon": 10, "latitude": 10, "longitude": 10})
     else:
         open_datasets_kwargs.setdefault("decode_times", False)
+        open_datasets_kwargs.setdefault("chunks", {"lat": 10, "lon": 10, "latitude": 10, "longitude": 10})
 
     ds_dict = convertors.open_file_as_xarray_dictionary(
         infile,

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -219,8 +219,10 @@ def area_selector_path(
     if isinstance(open_datasets_kwargs, list):
         for _open_dataset_kwargs in open_datasets_kwargs:
             _open_dataset_kwargs.setdefault("decode_times", False)
+            _open_dataset_kwargs.setdefault("chunks", -1)
     else:
         open_datasets_kwargs.setdefault("decode_times", False)
+        open_datasets_kwargs.setdefault("chunks", -1)
 
     ds_dict = convertors.open_file_as_xarray_dictionary(
         infile,

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -161,7 +161,7 @@ def area_selector(
         extra_kwargs = {k: kwargs.pop(k) for k in ["precision"] if k in kwargs}
         # Longitudes could return multiple slice in cases where the area wraps the "other side"
         lon_slices = get_dim_slices(
-            ds, lon_key, area["east"], area["west"] context, longitude=True, **extra_kwargs
+            ds, lon_key, area["east"], area["west"], context, longitude=True, **extra_kwargs
         )
         # We assume that latitudes won't be wrapped
         lat_slice = get_dim_slices(ds, lat_key, area["south"], area["north"], context, **extra_kwargs)[

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -139,6 +139,10 @@ def area_selector(
 ) -> xr.Dataset:
     north, east, south, west = area
 
+    # Fail safe, check that North and South are in the right order
+    if north < south:
+        south, north = north, south
+
     # Get any area_selector_kwargs from adaptor config, take a copy as they will be updated here
     kwargs = deepcopy(_kwargs)
 

--- a/cads_adaptors/tools/area_selector.py
+++ b/cads_adaptors/tools/area_selector.py
@@ -240,7 +240,7 @@ def area_selector_path(
     # TODO: Consider using the write to file methods in convertors sub-module
     if out_format in ["nc", "netcdf"]:
         out_paths = [
-            ds_area.compute().to_netcdf(os.path.join(fname_tag, "nc"))
+            ds_area.compute().to_netcdf(f"{fname_tag}.nc")
             for fname_tag, ds_area in ds_area_dict.items()
         ]
     else:

--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -519,7 +519,7 @@ def post_open_datasets_modifications(
 def open_netcdf_as_xarray_dictionary(
     netcdf_file: str,
     context: Context = Context(),
-    open_datasets_kwargs: dict[str, Any] = {},
+    open_datasets_kwargs: list[dict[str, Any]] | dict[str, Any] = {},
     post_open_datasets_kwargs: dict[str, Any] = {},
     **kwargs,
 ) -> dict[str, xr.Dataset]:
@@ -529,9 +529,14 @@ def open_netcdf_as_xarray_dictionary(
     """
     fname, _ = os.path.splitext(os.path.basename(netcdf_file))
 
-    assert isinstance(
-        open_datasets_kwargs, dict
-    ), "open_datasets_kwargs must be a dictionary for netCDF"
+    if isinstance(open_datasets_kwargs, list):
+        assert (
+            len(open_datasets_kwargs) == 1
+        ), "Only one set of open_datasets_kwargs allowed for netCDF"
+        open_datasets_kwargs = open_datasets_kwargs[0]
+        assert isinstance(
+            open_datasets_kwargs, dict
+        ), "open_datasets_kwargs must be a single dictionary for netCDF"
     # This is to maintain some consistency with the grib file opening
     open_datasets_kwargs = {
         "chunks": DEFAULT_CHUNKS,

--- a/tests/test_30_area_selector.py
+++ b/tests/test_30_area_selector.py
@@ -1,229 +1,270 @@
 import os
 import tempfile
-import unittest
 
 import numpy as np
+import pytest
+import requests
 import xarray as xr
 
+from cads_adaptors import Context
 from cads_adaptors.exceptions import InvalidRequest
 from cads_adaptors.tools.area_selector import (
     area_selector,
+    area_selector_paths,
     get_dim_slices,
     wrap_longitudes,
 )
 
 
-class TestWrapLongitudes(unittest.TestCase):
-    def test_wrap_longitudes(self):
-        dim_key = "test_dim"
-        start = 20
-        end = 40
-        coord_range = [0, 360]
+# class TestWrapLongitudes(unittest.TestCase):
+def test_wrap_longitudes():
+    dim_key = "test_dim"
+    start = 20
+    end = 40
+    coord_range = [0, 360]
 
-        result = wrap_longitudes(dim_key, start, end, coord_range)
-        self.assertEqual(result, [slice(start, end)])
+    result = wrap_longitudes(dim_key, start, end, coord_range)
+    assert result == [slice(start, end)]
 
-        start = -40
-        end = -20
-        result = wrap_longitudes(dim_key, start, end, coord_range)
-        self.assertEqual(result, [slice(start + 360, end + 360)])
+    start = -40
+    end = -20
+    result = wrap_longitudes(dim_key, start, end, coord_range)
+    assert result == [slice(start + 360, end + 360)]
 
-        start = 440
-        end = 420
-        result = wrap_longitudes(dim_key, start, end, coord_range)
-        self.assertEqual(result, [slice(start - 360, end - 360)])
+    start = 440
+    end = 420
+    result = wrap_longitudes(dim_key, start, end, coord_range)
+    assert result == [slice(start - 360, end - 360)]
 
-        start = -10
-        end = 30
-        result = wrap_longitudes(dim_key, start, end, coord_range)
-        self.assertEqual(
-            result, [slice(start + 360, coord_range[-1]), slice(coord_range[0], end)]
+    start = -10
+    end = 30
+    result = wrap_longitudes(dim_key, start, end, coord_range)
+    assert result == [slice(start + 360, coord_range[-1]), slice(coord_range[0], end)]
+
+
+def test_wrap_longitudes_oob():
+    dim_key = "test_dim"
+    start = -80
+    end = -40
+    coord_range = [-60, -20]
+
+    result = wrap_longitudes(dim_key, start, end, coord_range)
+    assert result == [slice(-80, -40)]
+
+    start = 280
+    end = 320
+    result = wrap_longitudes(dim_key, start, end, coord_range)
+    assert result == [slice(-80, -40)]
+
+
+TEST_DATA_1 = {
+    "temperature": (
+        ("time", "latitude", "longitude"),
+        [[[1, 2, 3, 4, 5, 6]] * 6] * 6,
+    )
+}
+TEST_COORDS_1 = {
+    "time": [1, 2, 3, 4, 5, 6],
+    "latitude": [-75, -45, -15, 15, 45, 75],
+    "longitude": [30, 90, 150, 210, 270, 330],
+}
+TEST_DS_1 = xr.Dataset(TEST_DATA_1, coords=TEST_COORDS_1)
+
+
+def test_get_dim_slices_within_limits():
+    result = get_dim_slices(TEST_DS_1, "latitude", -90, -40)
+    assert result == [slice(-90, -40)]
+
+    result = get_dim_slices(TEST_DS_1, "longitude", 10, 360, longitude=True)
+    assert result == [slice(10, 360)]
+
+
+def test_get_dim_slices_wrap_longitudes():
+    result = get_dim_slices(TEST_DS_1, "longitude", 300, 370, longitude=True)
+    assert result == [slice(300, 360), slice(0, 10)]
+
+
+def test_get_dim_slices_incompatible_area():
+    with pytest.raises(NotImplementedError):
+        get_dim_slices(TEST_DS_1, "latitude", -100, -91)
+
+
+def test_get_dim_slices_descending():
+    coords_desc = {
+        "time": [1, 2, 3, 4, 5, 6],
+        "latitude": [-75, -45, -15, 15, 45, 75][::-1],
+        "longitude": [30, 90, 150, 210, 270, 330][::-1],
+    }
+    ds_desc = xr.Dataset(TEST_DATA_1, coords=coords_desc)
+
+    result = get_dim_slices(ds_desc, "latitude", -90, -40)
+    assert result == [slice(-40, -90)]
+
+
+def test_get_dim_slices_outside_limits():
+    coords_desc = {
+        "time": [1, 2, 3, 4, 5, 6],
+        "latitude": [-75, -45, -15, 15, 45, 75],
+        "longitude": [90, 120, 150, 180, 210, 240],
+    }
+    ds_desc = xr.Dataset(TEST_DATA_1, coords=coords_desc)
+    result = get_dim_slices(ds_desc, "longitude", 10, 360, longitude=True)
+    assert result == [slice(10, 360)]
+
+
+TEST_COORDS_2 = {
+    "time": np.arange(5),
+    "latitude": np.arange(-89.5, 90, 1),
+    "longitude": np.arange(-179.5, 180, 1),
+}
+TEST_DATA_2 = {
+    "temperature": (
+        ("time", "latitude", "longitude"),
+        np.random.rand(5, 180, 360),
+    )
+}
+TEST_DS_2 = xr.Dataset(TEST_DATA_2, coords=TEST_COORDS_2)
+TEMP_FILENAME = "example_data.nc"
+
+
+def test_area_selector_regular_full_domain():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_file = os.path.join(temp_dir, TEMP_FILENAME)
+        TEST_DS_2.to_netcdf(test_file)
+        result = area_selector(test_file, area=[90, -180, -90, 180])
+        assert isinstance(result, xr.Dataset)
+        assert result.dims == TEST_DS_2.dims
+        assert np.allclose(result.latitude.values, TEST_DS_2.latitude.values)
+        assert np.allclose(result.longitude.values, TEST_DS_2.longitude.values)
+
+
+def test_area_selector_regular_sub_domain():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_file = os.path.join(temp_dir, TEMP_FILENAME)
+        TEST_DS_2.to_netcdf(test_file)
+        result = area_selector(test_file, area=[10, -10, -10, 10])
+        test_result = TEST_DS_2.sel(latitude=slice(-10, 10), longitude=slice(-10, 10))
+        assert isinstance(result, xr.Dataset)
+        assert result.dims == test_result.dims
+        assert np.allclose(result.latitude.values, test_result.latitude.values)
+        assert np.allclose(result.longitude.values, test_result.longitude.values)
+
+
+TEST_COORDS_3 = {
+    "time": np.arange(5),
+    "latitude": np.arange(30.5, 70, 1),
+    "longitude": np.arange(-20.5, 40, 1),
+}
+TEST_DATA_3 = {
+    "temperature": (
+        ("time", "latitude", "longitude"),
+        np.random.rand(5, 40, 61),
+    )
+}
+TEST_DS_3 = xr.Dataset(TEST_DATA_3, coords=TEST_COORDS_3)
+
+
+def test_area_selector_fully_oob():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_file = os.path.join(temp_dir, TEMP_FILENAME)
+        TEST_DS_3.to_netcdf(test_file)
+        result = area_selector(test_file, area=[90, -180, -90, 180])
+        assert isinstance(result, xr.Dataset)
+        assert result.dims == TEST_DS_3.dims
+        assert np.allclose(result.latitude.values, TEST_DS_3.latitude.values)
+        assert np.allclose(result.longitude.values, TEST_DS_3.longitude.values)
+
+
+def test_area_selector_regular_partially_oob_lons():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_file = os.path.join(temp_dir, TEMP_FILENAME)
+        TEST_DS_3.to_netcdf(test_file)
+        result = area_selector(test_file, area=[50, -40, 30, 10])
+        test_result = TEST_DS_3.sel(latitude=slice(30, 50), longitude=slice(-40, 10))
+        assert isinstance(result, xr.Dataset)
+        assert result.dims == test_result.dims
+        assert np.allclose(result.latitude.values, test_result.latitude.values)
+        assert np.allclose(result.longitude.values, test_result.longitude.values)
+
+
+def test_area_selector_regular_partially_oob_lats():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_file = os.path.join(temp_dir, TEMP_FILENAME)
+        TEST_DS_3.to_netcdf(test_file)
+        result = area_selector(test_file, area=[50, -10, 20, 10])
+        test_result = TEST_DS_3.sel(latitude=slice(20, 50), longitude=slice(-10, 10))
+        assert isinstance(result, xr.Dataset)
+        assert result.dims == test_result.dims
+        assert np.allclose(result.latitude.values, test_result.latitude.values)
+        assert np.allclose(result.longitude.values, test_result.longitude.values)
+
+
+# Test that InvalidRequest exception raised when a dimension has zero length
+def test_area_selector_zero_length_dim():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_file = os.path.join(temp_dir, TEMP_FILENAME)
+        TEST_DS_3.to_netcdf(test_file)
+        with pytest.raises(InvalidRequest):
+            area_selector(test_file, area=[50.4, -10.6, 50.3, -10.5])
+
+
+TEST_DATA_BASE_URL = (
+    "https://get.ecmwf.int/repository/test-data/test-data/cads-adaptors/"
+)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        f"{TEST_DATA_BASE_URL}/CAMS-GLOB-AIR_Glb_0.5x0.5_anthro_voc25_v1.1_2012.nc",
+        f"{TEST_DATA_BASE_URL}/C3S-312bL1-L3C-MONTHLY-SRB-ATSR2_ORAC_ERS2_199506_fv3.0.nc",
+    ],
+)
+def test_area_selector_real_files(url):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_file = os.path.join(temp_dir, TEMP_FILENAME)
+        remote_file = requests.get(url)
+        with open(test_file, "wb") as f:
+            f.write(remote_file.content)
+
+        result = area_selector(test_file, area=[90, -180, -90, 180])
+        assert isinstance(result, xr.Dataset)
+        assert result.sizes == {"time": 12, "level": 25, "lat": 360, "lon": 720}
+
+
+# Test with lists of urls
+@pytest.mark.parametrize(
+    "urls",
+    [
+        [
+            f"{TEST_DATA_BASE_URL}/CAMS-GLOB-AIR_Glb_0.5x0.5_anthro_voc25_v1.1_2012.nc",
+        ],
+        [
+            f"{TEST_DATA_BASE_URL}/CAMS-GLOB-AIR_Glb_0.5x0.5_anthro_voc25_v1.1_2012.nc",
+            f"{TEST_DATA_BASE_URL}/CAMS-GLOB-AIR_Glb_0.5x0.5_anthro_voc25_v1.1_2013.nc",
+            f"{TEST_DATA_BASE_URL}/CAMS-GLOB-AIR_Glb_0.5x0.5_anthro_voc25_v1.1_2014.nc",
+        ],
+        [
+            # Mixed bag of files and formats
+            f"{TEST_DATA_BASE_URL}/CAMS-GLOB-AIR_Glb_0.5x0.5_anthro_voc25_v1.1_2012.nc",
+            f"{TEST_DATA_BASE_URL}/CAMS-GLOB-BIO_v1.1_carbon-monoxide_2014.nc",
+            f"{TEST_DATA_BASE_URL}/C3S-312bL1-L3C-MONTHLY-SRB-ATSR2_ORAC_ERS2_199506_fv3.0.nc",
+        ],
+    ],
+)
+def test_area_selector_paths_real_files(urls):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_files = []
+        for i, file in enumerate(urls):
+            remote_file = requests.get(file)
+            test_file = os.path.join(temp_dir, f"test-{i}.nc")
+            with open(test_file, "wb") as f:
+                f.write(remote_file.content)
+            test_files.append(test_file)
+
+        result = area_selector_paths(
+            test_files, area=[90, -180, -90, 180], context=Context()
         )
-
-    def test_wrap_longitudes_oob(self):
-        dim_key = "test_dim"
-        start = -80
-        end = -40
-        coord_range = [-60, -20]
-
-        result = wrap_longitudes(dim_key, start, end, coord_range)
-        self.assertEqual(result, [slice(-80, -40)])
-
-        start = 280
-        end = 320
-        result = wrap_longitudes(dim_key, start, end, coord_range)
-        self.assertEqual(result, [slice(-80, -40)])
-
-
-class TestGetDimSlices(unittest.TestCase):
-    def setUp(self):
-        # Create a sample xarray dataset for testing
-        self.coords = {
-            "time": [1, 2, 3, 4, 5, 6],
-            "latitude": [-75, -45, -15, 15, 45, 75],
-            "longitude": [30, 90, 150, 210, 270, 330],
-        }
-        self.data = {
-            "temperature": (
-                ("time", "latitude", "longitude"),
-                [[[1, 2, 3, 4, 5, 6]] * 6] * 6,
-            )
-        }
-        self.ds = xr.Dataset(self.data, coords=self.coords)
-
-    def test_get_dim_slices_within_limits(self):
-        result = get_dim_slices(self.ds, "latitude", -90, -40)
-        self.assertEqual(result, [slice(-90, -40)])
-
-        result = get_dim_slices(self.ds, "longitude", 10, 360, longitude=True)
-        self.assertEqual(result, [slice(10, 360)])
-
-    def test_get_dim_slices_wrap_longitudes(self):
-        result = get_dim_slices(self.ds, "longitude", 300, 370, longitude=True)
-        self.assertEqual(result, [slice(300, 360), slice(0, 10)])
-
-    def test_get_dim_slices_incompatible_area(self):
-        with self.assertRaises(NotImplementedError):
-            get_dim_slices(self.ds, "latitude", -100, -91)
-
-    def test_get_dim_slices_descending(self):
-        coords_desc = {
-            "time": [1, 2, 3, 4, 5, 6],
-            "latitude": [-75, -45, -15, 15, 45, 75][::-1],
-            "longitude": [30, 90, 150, 210, 270, 330][::-1],
-        }
-        ds_desc = xr.Dataset(self.data, coords=coords_desc)
-
-        result = get_dim_slices(ds_desc, "latitude", -90, -40)
-        self.assertEqual(result, [slice(-40, -90)])
-
-    def test_get_dim_slices_outside_limits(self):
-        coords_desc = {
-            "time": [1, 2, 3, 4, 5, 6],
-            "latitude": [-75, -45, -15, 15, 45, 75],
-            "longitude": [90, 120, 150, 180, 210, 240],
-        }
-        ds_desc = xr.Dataset(self.data, coords=coords_desc)
-        result = get_dim_slices(ds_desc, "longitude", 10, 360, longitude=True)
-        self.assertEqual(result, [slice(10, 360)])
-
-
-class TestAreaSelector(unittest.TestCase):
-    def setUp(self):
-        # Create a sample xarray dataset for testing
-        self.coords = {
-            "time": np.arange(5),
-            "latitude": np.arange(-89.5, 90, 1),
-            "longitude": np.arange(-179.5, 180, 1),
-        }
-        self.data = {
-            "temperature": (
-                ("time", "latitude", "longitude"),
-                np.random.rand(5, 180, 360),
-            )
-        }
-        self.ds = xr.Dataset(self.data, coords=self.coords)
-        self.input_file = "example_data.nc"
-
-    def test_area_selector_regular_full_domain(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = os.path.join(temp_dir, self.input_file)
-            self.ds.to_netcdf(test_file)
-            result = area_selector(test_file, area=[90, -180, -90, 180])
-            self.assertIsInstance(result, xr.Dataset)
-            self.assertEqual(result.dims, self.ds.dims)
-            self.assertTrue(
-                np.allclose(result.latitude.values, self.ds.latitude.values)
-            )
-            self.assertTrue(
-                np.allclose(result.longitude.values, self.ds.longitude.values)
-            )
-
-    def test_area_selector_regular_sub_domain(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = os.path.join(temp_dir, self.input_file)
-            self.ds.to_netcdf(test_file)
-            result = area_selector(test_file, area=[10, -10, -10, 10])
-            test_result = self.ds.sel(latitude=slice(-10, 10), longitude=slice(-10, 10))
-            self.assertIsInstance(result, xr.Dataset)
-            self.assertEqual(result.dims, test_result.dims)
-            self.assertTrue(
-                np.allclose(result.latitude.values, test_result.latitude.values)
-            )
-            self.assertTrue(
-                np.allclose(result.longitude.values, test_result.longitude.values)
-            )
-
-
-class TestAreaSelectorOOB(unittest.TestCase):
-    def setUp(self):
-        # Create a sample xarray dataset for testing
-        self.coords = {
-            "time": np.arange(5),
-            "latitude": np.arange(30.5, 70, 1),
-            "longitude": np.arange(-20.5, 40, 1),
-        }
-        self.data = {
-            "temperature": (
-                ("time", "latitude", "longitude"),
-                np.random.rand(5, 40, 61),
-            )
-        }
-        self.ds = xr.Dataset(self.data, coords=self.coords)
-        self.input_file = "example_data.nc"
-
-    def test_area_selector_fully_oob(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = os.path.join(temp_dir, self.input_file)
-            self.ds.to_netcdf(test_file)
-            result = area_selector(test_file, area=[90, -180, -90, 180])
-            self.assertIsInstance(result, xr.Dataset)
-            self.assertEqual(result.dims, self.ds.dims)
-            self.assertTrue(
-                np.allclose(result.latitude.values, self.ds.latitude.values)
-            )
-            self.assertTrue(
-                np.allclose(result.longitude.values, self.ds.longitude.values)
-            )
-
-    def test_area_selector_regular_partially_oob_lons(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = os.path.join(temp_dir, self.input_file)
-            self.ds.to_netcdf(test_file)
-            result = area_selector(test_file, area=[50, -40, 30, 10])
-            test_result = self.ds.sel(latitude=slice(30, 50), longitude=slice(-40, 10))
-            self.assertIsInstance(result, xr.Dataset)
-            self.assertEqual(result.dims, test_result.dims)
-            self.assertTrue(
-                np.allclose(result.latitude.values, test_result.latitude.values)
-            )
-            self.assertTrue(
-                np.allclose(result.longitude.values, test_result.longitude.values)
-            )
-
-    def test_area_selector_regular_partially_oob_lats(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = os.path.join(temp_dir, self.input_file)
-            self.ds.to_netcdf(test_file)
-            result = area_selector(test_file, area=[50, -10, 20, 10])
-            test_result = self.ds.sel(latitude=slice(20, 50), longitude=slice(-10, 10))
-            self.assertIsInstance(result, xr.Dataset)
-            self.assertEqual(result.dims, test_result.dims)
-            self.assertTrue(
-                np.allclose(result.latitude.values, test_result.latitude.values)
-            )
-            self.assertTrue(
-                np.allclose(result.longitude.values, test_result.longitude.values)
-            )
-
-    # Test that InvalidRequest exception raised when a dimension has zero length
-    def test_area_selector_zero_length_dim(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = os.path.join(temp_dir, self.input_file)
-            self.ds.to_netcdf(test_file)
-            with self.assertRaises(InvalidRequest):
-                area_selector(test_file, area=[50.4, -10.6, 50.3, -10.5])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert isinstance(result, list)
+        assert len(result) == len(urls)
+        assert all(isinstance(r, str) for r in result)

--- a/tests/test_30_area_selector.py
+++ b/tests/test_30_area_selector.py
@@ -229,7 +229,6 @@ def test_area_selector_real_files(url):
 
         result = area_selector(test_file, area=[90, -180, -90, 180])
         assert isinstance(result, xr.Dataset)
-        assert result.sizes == {"time": 12, "level": 25, "lat": 360, "lon": 720}
 
 
 # Test with lists of urls


### PR DESCRIPTION
To handle for some trivial issues with some data formats not meeting CF convenstions (e.g. bad time units and undefined coordinates), we need to be to provide kwargs to the area selection postprocessor.

This PR updates the area_selector post-processor to use the open_file_as_xarray_dict method in the convertors sub-module, and facilitates providing additional keywords. Also, as this function is not concerned with the time dimensions, we default the decode_times kwarg to False so that it does not fail with bad time units.

Summary of the changes in functions : 

1.  the area_select method is now xr.Dataset in, xr.Dataset out. Previously it was filepath (str) in, xr.Dataset out
2. new area_select_path method is filepath (str) in, list of filepaths out. This is to account for the potential future feature that one in file (grib) may result in multiple out files. It: a. opens the file with the general open_file_aas_xarray_dict method from the convertors sub-module; (b) Calls area_select on each xarray.Dataset; (c) Writes the datasets to file[s] and returns
3. The area_select_paths has been updated to simplly iterate over area_select_path for each filepath


Additionally, the unit-tests have been brought into line with the other unit-tests, along with some minor updates to account for the new API of the funcitons.