### PR TITLE
offline logger to match cads-worker

### DIFF
--- a/cads_adaptors/tools/logger.py
+++ b/cads_adaptors/tools/logger.py
@@ -1,9 +1,3 @@
-# TODO: use a better logger, where better means standardised to cads logs in terms of formatting
-import logging
-import os
+import structlog
 
-logger = logging.getLogger("adaptors")
-logger.setLevel(os.getenv("ADAPTORS_LOG_LEVEL", "DEBUG"))
-ch = logging.StreamHandler()
-
-logger.addHandler(ch)
+logger = structlog.getLogger(__name__)

--- a/ci/environment-ci.yml
+++ b/ci/environment-ci.yml
@@ -19,6 +19,7 @@ dependencies:
 - types-pyyaml
 - types-requests
 - pytest-localftpserver
+- structlog
 - pip:
   - git+https://github.com/ecmwf-projects/cacholote.git
   - git+https://github.com/ecmwf-projects/cads-mars-server

--- a/ci/environment-ci.yml
+++ b/ci/environment-ci.yml
@@ -19,7 +19,6 @@ dependencies:
 - types-pyyaml
 - types-requests
 - pytest-localftpserver
-- structlog
 - pip:
   - git+https://github.com/ecmwf-projects/cacholote.git
   - git+https://github.com/ecmwf-projects/cads-mars-server

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
 - pyyaml
 - requests
 - sqlalchemy
+- structlog
 - tabulate
 - tqdm
 - xarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   # Only mandatory dependencies required by the broker and retrieve-api images
   "DateTimeRange",
   "python-dateutil",
+  "structlog",
   "jsonschema"
 ]
 description = "CADS data retrieve utilities to be used by adaptors"
@@ -51,7 +52,6 @@ complete = [
   "requests",
   "rooki",
   "sqlalchemy",
-  "structlog",
   "tabulate",
   "tqdm",
   "xarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ complete = [
   "requests",
   "rooki",
   "sqlalchemy",
+  "structlog",
   "tabulate",
   "tqdm",
   "xarray",


### PR DESCRIPTION
Updating the offline logger used by unit-tests to match that of cads-worker. This means we can add additional kwargs to logger calls without breaking the tests.