### PR TITLE
Feature/arco adaptor generalised

### DIFF
--- a/cads_adaptors/adaptors/arco.py
+++ b/cads_adaptors/adaptors/arco.py
@@ -43,17 +43,15 @@ class ArcoDataLakeCdsAdaptor(cds.AbstractCdsAdaptor):
     def _normalise_date(self, request: Request) -> None:
         date_key = self.config.get("date_key", "date")
         date = ensure_list(request.get(date_key))
-        if len(date) == 1:
-            split = str(date[0]).split("/")
-            date_range = [split[0], split[-1]]
-        elif len(date) == 2:
-            date_range = date
-        else:
+        date_range = sorted(str(date[0]).split("/") if len(date) == 1 else date)
+        if len(date_range) == 1:
+            date_range *= 2
+        if len(date_range) != 2:
             raise InvalidRequest(
                 'Please specify a single date range using the format "yyyy-mm-dd/yyyy-mm-dd" or '
                 '["yyyy-mm-dd", "yyyy-mm-dd"].'
             )
-        date_range = sorted(date_range)
+
         # Embargo check
         if "embargo" in self.config and self.config["embargo"]:
             embargo = self.config["embargo"]

--- a/cads_adaptors/adaptors/arco.py
+++ b/cads_adaptors/adaptors/arco.py
@@ -1,6 +1,9 @@
 import copy
 import tempfile
+from datetime import UTC, datetime, timedelta
 from typing import Any
+
+from dateutil.parser import parse as dtparse
 
 from cads_adaptors.adaptors import Request, cds
 from cads_adaptors.exceptions import ArcoDataLakeNoDataError, InvalidRequest
@@ -52,10 +55,6 @@ class ArcoDataLakeCdsAdaptor(cds.AbstractCdsAdaptor):
 
         # Embargo check
         if "embargo" in self.config and self.config["embargo"]:
-            from datetime import UTC, datetime, timedelta
-
-            from dateutil.parser import parse as dtparse
-
             embargo = self.config["embargo"]
             embargo_error_time_format: str = embargo.pop(
                 "error_time_format", "%Y-%m-%d %H:00"

--- a/cads_adaptors/adaptors/arco.py
+++ b/cads_adaptors/adaptors/arco.py
@@ -1,5 +1,6 @@
 import copy
 import tempfile
+from typing import Any
 
 from cads_adaptors.adaptors import Request, cds
 from cads_adaptors.exceptions import ArcoDataLakeNoDataError, InvalidRequest
@@ -135,17 +136,17 @@ class ArcoDataLakeCdsAdaptor(cds.AbstractCdsAdaptor):
             self.context.add_user_visible_error(f"Invalid variable: {exc}.")
             raise
 
-        # Normalised request is guarenteed to have a date key, set to a list of two values
-        date = request[self.config.get("date_key", "date")]
-
+        # Normalised request is guarenteed to have a value for date_key, set to a list of two values
+        date_range = request[self.config.get("date_key", "date")]
         source_date_key = self.config.get("source_date_key", "time")
+        selection: dict[str, Any] = {source_date_key: slice(*date_range)}
         try:
-            ds = ds.sel(**{source_date_key: slice(*date)})
+            ds = ds.sel(**selection)
         except TypeError:
-            self.context.add_user_visible_error(f"Invalid {date=}")
+            self.context.add_user_visible_error(f"Invalid {date_range=}")
             raise
         if not ds.sizes[source_date_key]:
-            msg = f"No data found for {date=}"
+            msg = f"No data found for {date_range=}"
             self.context.add_user_visible_error(msg)
             raise ArcoDataLakeNoDataError(msg)
 

--- a/cads_adaptors/adaptors/arco.py
+++ b/cads_adaptors/adaptors/arco.py
@@ -40,10 +40,11 @@ class ArcoDataLakeCdsAdaptor(cds.AbstractCdsAdaptor):
         except (ValueError, TypeError):
             raise InvalidRequest(f"Invalid {location=}. {msg}")
 
-    def _normalise_date(self, request: Request, date_key="date") -> None:
+    def _normalise_date(self, request: Request) -> None:
+        date_key = self.config.get("date_key", "date")
         date = ensure_list(request.get(date_key))
         if len(date) == 1:
-            split = sorted(str(date[0]).split("/"))
+            split = str(date[0]).split("/")
             date_range = [split[0], split[-1]]
         elif len(date) == 2:
             date_range = date
@@ -52,7 +53,7 @@ class ArcoDataLakeCdsAdaptor(cds.AbstractCdsAdaptor):
                 'Please specify a single date range using the format "yyyy-mm-dd/yyyy-mm-dd" or '
                 '["yyyy-mm-dd", "yyyy-mm-dd"].'
             )
-
+        date_range = sorted(date_range)
         # Embargo check
         if "embargo" in self.config and self.config["embargo"]:
             embargo = self.config["embargo"]
@@ -103,7 +104,7 @@ class ArcoDataLakeCdsAdaptor(cds.AbstractCdsAdaptor):
         request = copy.deepcopy(request)
         self._normalise_variable(request)
         self._normalise_location(request)
-        self._normalise_date(request, date_key=self.config.get("date_key", "date"))
+        self._normalise_date(request)
         self._normalise_data_format(request)
 
         request = super().normalise_request(request)

--- a/cads_adaptors/adaptors/arco.py
+++ b/cads_adaptors/adaptors/arco.py
@@ -58,7 +58,8 @@ class ArcoDataLakeCdsAdaptor(cds.AbstractCdsAdaptor):
         if "embargo" in self.config and self.config["embargo"]:
             embargo = self.config["embargo"]
             embargo_error_time_format: str = embargo.pop(
-                "error_time_format", "%Y-%m-%d %H:00"
+                "error_time_format",
+                "%Y-%m-%d",  # Default to daily embargo
             )
             embargo_datetime = datetime.now(UTC) - timedelta(**embargo)
             if dtparse(date_range[0]).date() > embargo_datetime.date():

--- a/tests/test_50_arco_adaptor.py
+++ b/tests/test_50_arco_adaptor.py
@@ -140,7 +140,7 @@ def test_arco_normalise_request(
     ),
 )
 def test_arco_normalise_request_embargo_pass(
-    in_date: str | int | list[str, int],
+    in_date: str | int | list[str | int],
     out_date: list[str],
     arco_adaptor: ArcoDataLakeCdsAdaptor,
     monkeypatch: pytest.MonkeyPatch,
@@ -174,7 +174,7 @@ def test_arco_normalise_request_embargo_pass(
     ),
 )
 def test_arco_normalise_request_embargo_raise(
-    in_date: str | int | list[str, int],
+    in_date: str | int | list[str | int],
     arco_adaptor: ArcoDataLakeCdsAdaptor,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -208,7 +208,7 @@ def test_arco_normalise_request_embargo_raise(
     ),
 )
 def test_arco_normalise_request_embargo_warn(
-    in_date: str | int | list[str, int],
+    in_date: str | int | list[str | int],
     out_date: list[str],
     arco_adaptor: ArcoDataLakeCdsAdaptor,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_50_arco_adaptor.py
+++ b/tests/test_50_arco_adaptor.py
@@ -375,7 +375,7 @@ def test_arco_data_format(
                 "date": 1990,
             },
             ArcoDataLakeNoDataError,
-            "No data found for date=['1990', '1990']",
+            "No data found for date_range=['1990', '1990']",
         ),
     ],
 )

--- a/tests/test_50_arco_adaptor.py
+++ b/tests/test_50_arco_adaptor.py
@@ -63,7 +63,47 @@ def arco_adaptor(
                     "latitude": 2.0,
                     "longitude": 1.0,
                 },
-                "date": ["1990/1990"],
+                "date": ["1990", "1990"],
+                "variable": ["bar", "foo"],
+            },
+        ),
+        (
+            {
+                "data_format": ["nc"],
+                "location": {
+                    "longitude": 1,
+                    "latitude": "2",
+                },
+                "date": "1990/1991",
+                "variable": ("foo", "bar"),
+            },
+            {
+                "data_format": "netcdf",
+                "location": {
+                    "latitude": 2.0,
+                    "longitude": 1.0,
+                },
+                "date": ["1990", "1991"],
+                "variable": ["bar", "foo"],
+            },
+        ),
+        (
+            {
+                "data_format": ["nc"],
+                "location": {
+                    "longitude": 1,
+                    "latitude": "2",
+                },
+                "date": ["1990", "1991"],
+                "variable": ("foo", "bar"),
+            },
+            {
+                "data_format": "netcdf",
+                "location": {
+                    "latitude": 2.0,
+                    "longitude": 1.0,
+                },
+                "date": ["1990", "1991"],
                 "variable": ["bar", "foo"],
             },
         ),

--- a/tests/test_50_arco_adaptor.py
+++ b/tests/test_50_arco_adaptor.py
@@ -48,15 +48,6 @@ def arco_adaptor(
     "original,expected",
     [
         (
-            {"variable": "foo", "location": {"latitude": 0, "longitude": 0}},
-            {
-                "data_format": "netcdf",
-                "location": {"latitude": 0.0, "longitude": 0.0},
-                "date": [],
-                "variable": ["foo"],
-            },
-        ),
-        (
             {
                 "data_format": ["nc"],
                 "location": {

--- a/tests/test_50_arco_adaptor.py
+++ b/tests/test_50_arco_adaptor.py
@@ -366,7 +366,7 @@ def test_arco_data_format(
                 "date": "foo",
             },
             TypeError,
-            "Invalid date=['foo', 'foo']",
+            "Invalid date_range=['foo', 'foo']",
         ),
         (
             {

--- a/tests/test_50_arco_adaptor.py
+++ b/tests/test_50_arco_adaptor.py
@@ -180,7 +180,7 @@ def test_arco_normalise_request_embargo_warn(
         request = arco_adaptor.normalise_request(request)
         assert any(
             "Part of the data you have requested is under embargo" in message
-            for message in arco_adaptor.context.user_visible_errors
+            for message in arco_adaptor.context.user_visible_errors   # type: ignore[attr-defined]
         )
 
 

--- a/tests/test_50_arco_adaptor.py
+++ b/tests/test_50_arco_adaptor.py
@@ -154,6 +154,7 @@ def test_arco_normalise_request(
             {
                 "variable": "FOO",
                 "location": {"latitude": 0, "longitude": 0},
+                "date": [1, 2],
                 "data_format": ["foo", "bar"],
             },
             "specify a single data_format",
@@ -162,6 +163,7 @@ def test_arco_normalise_request(
             {
                 "variable": "FOO",
                 "location": {"latitude": 0, "longitude": 0},
+                "date": [1, 2],
                 "data_format": "foo",
             },
             "Invalid data_format",
@@ -194,6 +196,7 @@ def test_arco_select_variable(
         {
             "variable": variable,
             "location": {"latitude": 0, "longitude": 0},
+            "date": "2000",
         }
     )
     ds = xr.open_dataset(fp.name)
@@ -203,7 +206,7 @@ def test_arco_select_variable(
 
 
 def test_arco_select_location(arco_adaptor: ArcoDataLakeCdsAdaptor):
-    request = {"variable": "FOO", "location": {"latitude": 31, "longitude": "41"}}
+    request = {"variable": "FOO", "location": {"latitude": 31, "longitude": "41"}, "date": "2000"}
     fp = arco_adaptor.retrieve(request)
     ds = xr.open_dataset(fp.name)
     assert ds["latitude"].item() == 30
@@ -251,6 +254,7 @@ def test_arco_data_format(
     request = {
         "variable": "FOO",
         "location": {"latitude": 0, "longitude": 0},
+        "date": "2000",
         "data_format": data_format,
     }
     fp = arco_adaptor.retrieve(request)
@@ -280,6 +284,7 @@ def test_arco_data_format(
             {
                 "variable": "wrong",
                 "location": {"latitude": 0, "longitude": 0},
+                "date": "2000",
             },
             KeyError,
             "Invalid variable: 'wrong'.",
@@ -291,7 +296,7 @@ def test_arco_data_format(
                 "date": "foo",
             },
             TypeError,
-            "Invalid date=['foo/foo']",
+            "Invalid date=['foo', 'foo']",
         ),
         (
             {
@@ -300,7 +305,7 @@ def test_arco_data_format(
                 "date": 1990,
             },
             ArcoDataLakeNoDataError,
-            "No data found for date=['1990/1990']",
+            "No data found for date=['1990', '1990']",
         ),
     ],
 )
@@ -324,6 +329,7 @@ def test_connection_problems(
             {
                 "variable": "FOO",
                 "location": {"latitude": 0, "longitude": 0},
+                "date": "2000",
             }
         )
     assert (

--- a/tests/test_50_arco_adaptor.py
+++ b/tests/test_50_arco_adaptor.py
@@ -180,7 +180,7 @@ def test_arco_normalise_request_embargo_warn(
         request = arco_adaptor.normalise_request(request)
         assert any(
             "Part of the data you have requested is under embargo" in message
-            for message in arco_adaptor.context.user_visible_errors   # type: ignore[attr-defined]
+            for message in arco_adaptor.context.user_visible_errors  # type: ignore[attr-defined]
         )
 
 


### PR DESCRIPTION
Some adjustments to make the adaptor more generalisable:

1. date key in request can be specified in the config (so we can choose date or date_range)
2. date values can also be a length 2 list [start, end]
3. date is normalised to a list [start, end]
4. download_format configurable from config
5. test updated now that date is a mandatory key
6. tests added to check normalisation of date = [start, end] format
7. source_date_key is configurable (dimension name in zarr)
8. Added embargo enforcement
