### PR TITLE
fallback to old payload format in case the new fails

### DIFF
--- a/tests/test_cadsobs_adaptor.py
+++ b/tests/test_cadsobs_adaptor.py
@@ -176,10 +176,10 @@ TEST_ADAPTOR_CONFIG = {
     "mapping": {
         "remap": {
             "time_aggregation": {
-                "daily": "USCRN_DAILY",
-                "hourly": "USCRN_HOURLY",
-                "monthly": "USCRN_MONTHLY",
-                "sub_hourly": "USCRN_SUBHOURLY",
+                "daily": "uscrn_daily",
+                "hourly": "uscrn_hourly",
+                "monthly": "uscrn_monthly",
+                "sub_hourly": "uscrn_subhourly",
             },
             "variable": {
                 "maximum_air_temperature": "daily_maximum_air_temperature",


### PR DESCRIPTION
I modified CadsobsApiClient.get_objects_to_retrieve So it falls back to old payload format in case the new one fails.
We also capture more exceptions when trying to decode the error message Also capture more exceptions when trying to decode the error message to get the TypeError: string indices must be integers, not 'str' and also KeyError in case there is one.