### PR TITLE
Feature/embargo handle non standard times

### DIFF
--- a/cads_adaptors/tools/date_tools.py
+++ b/cads_adaptors/tools/date_tools.py
@@ -358,14 +358,14 @@ def implement_embargo(
                     if len(times) > 0:
                         extra_request = {**req, "date": [date], "time": times}
                         _extra_requests.append(extra_request)
+            else:
+                # Request has been effected by embargo, therefore should not be cached
+                cacheable = False
+
 
         if len(_out_dates) > 0:
             req["date"] = _out_dates
             out_requests.append(req)
-
-        # Check if dates have changed
-        if in_dates != _out_dates:
-            cacheable = False
 
         # append any extra requests to the end
         out_requests += _extra_requests

--- a/cads_adaptors/tools/date_tools.py
+++ b/cads_adaptors/tools/date_tools.py
@@ -372,8 +372,8 @@ def implement_embargo(
             f"{embargo_datetime.strftime(embargo_error_time_format)}",
         )
 
-    if out_requests != requests:
-        # One final check that the embargo has not modified the requests
+    if len(out_requests) != len(requests):
+        # One final check that the embargo has not added or removed any complete requests
         cacheable = False
 
     return out_requests, cacheable

--- a/cads_adaptors/tools/date_tools.py
+++ b/cads_adaptors/tools/date_tools.py
@@ -362,7 +362,6 @@ def implement_embargo(
                 # Request has been effected by embargo, therefore should not be cached
                 cacheable = False
 
-
         if len(_out_dates) > 0:
             req["date"] = _out_dates
             out_requests.append(req)

--- a/cads_adaptors/tools/date_tools.py
+++ b/cads_adaptors/tools/date_tools.py
@@ -326,10 +326,9 @@ def implement_embargo(
     embargo_datetime = datetime.now(UTC) - timedelta(**embargo)
     out_requests = []
     for req in requests:
-        in_dates = req.get("date", [])
         _out_dates = []
         _extra_requests = []
-        for date in in_dates:
+        for date in req.get("date", []):
             this_date = dtparse(str(date)).date()
             if this_date < embargo_datetime.date() or (
                 not filter_timesteps and this_date == embargo_datetime.date()

--- a/cads_adaptors/tools/date_tools.py
+++ b/cads_adaptors/tools/date_tools.py
@@ -372,8 +372,8 @@ def implement_embargo(
             f"{embargo_datetime.strftime(embargo_error_time_format)}",
         )
 
-    if len(out_requests) != len(requests):
-        # One final check that the embargo has not added or removed any complete requests
+    if out_requests != requests:
+        # One final check that the embargo has not modified the requests
         cacheable = False
 
     return out_requests, cacheable

--- a/cads_adaptors/tools/date_tools.py
+++ b/cads_adaptors/tools/date_tools.py
@@ -363,6 +363,7 @@ def implement_embargo(
             req["date"] = _out_dates
             out_requests.append(req)
 
+        # Check if dates have changed
         if in_dates != _out_dates:
             cacheable = False
 

--- a/tests/test_10_datetools.py
+++ b/tests/test_10_datetools.py
@@ -1,0 +1,55 @@
+import pytest
+from datetime import datetime, UTC
+from unittest.mock import patch
+
+# Assuming the function is in a module named `embargo_handler`
+from cads_adaptors.tools.date_tools import implement_embargo
+from cads_adaptors.exceptions import InvalidRequest
+
+def test_implement_embargo_no_embargo():
+    requests = [{"date": ["2025-03-01"]}]
+    embargo = {}
+    out_requests, cacheable = implement_embargo(requests, embargo)
+    assert out_requests == requests
+    assert cacheable is True
+
+def test_implement_embargo_with_days():
+    requests = [{"date": ["2025-03-01", datetime.now().strftime("%Y-%m-%d")]}]
+    embargo = {"days": 5}
+    out_requests, cacheable = implement_embargo(requests, embargo)
+    assert out_requests == [{"date": ["2025-03-01"]}]
+    assert cacheable is False
+
+def test_implement_embargo_with_months():
+    requests = [{"date": ["2025-02-01", datetime.now().strftime("%Y-%m-%d")]}]
+    embargo = {"months": 1}  # Should translate to roughly 30 days
+    out_requests, cacheable = implement_embargo(requests, embargo)
+    assert out_requests == [{"date": ["2025-02-01"]}]
+    assert cacheable is False
+
+def test_implement_embargo_all_filtered():
+    requests = [{"date": ["2025-03-01", datetime.now().strftime("%Y-%m-%d")]}]
+    embargo = {"days": 10}
+    with pytest.raises(InvalidRequest, match="None of the data you have requested is available yet"):
+        implement_embargo(requests, embargo)
+
+def test_implement_embargo_filter_timesteps():
+    requests = [{"date": ["2025-03-01", "2025-03-02"], "time": ["00:00", "12:00"]}]
+    embargo = {"days": 0, "hours": 6}  # DEFAULT: "filter_timesteps": True}
+    with patch("cads_adaptors.tools.date_tools.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2025, 3, 2, 16, tzinfo=UTC)
+        out_requests, cacheable = implement_embargo(requests, embargo)
+    assert len(out_requests) == 2
+    assert out_requests[0] == {"date": ["2025-03-01"], "time": ["00:00", "12:00"]}
+    assert out_requests[1] == {"date": ["2025-03-02"], "time": ["00:00"]}
+    assert cacheable is False
+
+    # Check the case with filter_timesteps=False
+    requests = [{"date": ["2025-03-01", "2025-03-02"], "time": ["00:00", "12:00"]}]
+    embargo = {"days": 0, "hours": 6, "filter_timesteps": False}
+    with patch("cads_adaptors.tools.date_tools.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2025, 3, 2, 16, tzinfo=UTC)
+        out_requests, cacheable = implement_embargo(requests, embargo)
+    assert len(out_requests) == 1
+    assert out_requests[0] == {"date": ["2025-03-01", "2025-03-02"], "time": ["00:00", "12:00"]}
+    assert cacheable is True

--- a/tests/test_10_datetools.py
+++ b/tests/test_10_datetools.py
@@ -1,10 +1,13 @@
-import pytest
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from unittest.mock import patch
+
+import pytest
+
+from cads_adaptors.exceptions import InvalidRequest
 
 # Assuming the function is in a module named `embargo_handler`
 from cads_adaptors.tools.date_tools import implement_embargo
-from cads_adaptors.exceptions import InvalidRequest
+
 
 def test_implement_embargo_no_embargo():
     requests = [{"date": ["2025-03-01"]}]
@@ -13,12 +16,14 @@ def test_implement_embargo_no_embargo():
     assert out_requests == requests
     assert cacheable is True
 
+
 def test_implement_embargo_with_days():
     requests = [{"date": ["2025-03-01", datetime.now().strftime("%Y-%m-%d")]}]
     embargo = {"days": 5}
     out_requests, cacheable = implement_embargo(requests, embargo)
     assert out_requests == [{"date": ["2025-03-01"]}]
     assert cacheable is False
+
 
 def test_implement_embargo_with_months():
     requests = [{"date": ["2025-02-01", datetime.now().strftime("%Y-%m-%d")]}]
@@ -27,11 +32,15 @@ def test_implement_embargo_with_months():
     assert out_requests == [{"date": ["2025-02-01"]}]
     assert cacheable is False
 
+
 def test_implement_embargo_all_filtered():
     requests = [{"date": ["2025-03-01", datetime.now().strftime("%Y-%m-%d")]}]
     embargo = {"days": 10}
-    with pytest.raises(InvalidRequest, match="None of the data you have requested is available yet"):
+    with pytest.raises(
+        InvalidRequest, match="None of the data you have requested is available yet"
+    ):
         implement_embargo(requests, embargo)
+
 
 def test_implement_embargo_filter_timesteps():
     requests = [{"date": ["2025-03-01", "2025-03-02"], "time": ["00:00", "12:00"]}]
@@ -51,5 +60,8 @@ def test_implement_embargo_filter_timesteps():
         mock_datetime.now.return_value = datetime(2025, 3, 2, 16, tzinfo=UTC)
         out_requests, cacheable = implement_embargo(requests, embargo)
     assert len(out_requests) == 1
-    assert out_requests[0] == {"date": ["2025-03-01", "2025-03-02"], "time": ["00:00", "12:00"]}
+    assert out_requests[0] == {
+        "date": ["2025-03-01", "2025-03-02"],
+        "time": ["00:00", "12:00"],
+    }
     assert cacheable is True


### PR DESCRIPTION
Add a new option to the embargo configuration, "filter_timesteps". This will allow us to prevent timesteps being filtered for datasets where it is problematic. e.g. with seasonal monthly which has an enforced value for `time = "all"`.