### PR TITLE
Rename spatial coordinates to latitude and longitude

### DIFF
--- a/cads_adaptors/adaptors/cadsobs/csv.py
+++ b/cads_adaptors/adaptors/cadsobs/csv.py
@@ -51,15 +51,11 @@ def get_csv_header(
 {uncertainty_str}
 ########################################################################################
 """
-    if "latitude|station_configuration" in cdm_lite_dataset:
-        coord_table = "station_configuration"
-    else:
-        coord_table = "header_table"
     area = "{:.2f}/{:.2f}/{:.2f}/{:.2f}".format(
-        cdm_lite_dataset[f"latitude|{coord_table}"].min().compute().item(),
-        cdm_lite_dataset[f"latitude|{coord_table}"].max().compute().item(),
-        cdm_lite_dataset[f"longitude|{coord_table}"].min().compute().item(),
-        cdm_lite_dataset[f"longitude|{coord_table}"].max().compute().item(),
+        cdm_lite_dataset["latitude"].min().compute().item(),
+        cdm_lite_dataset["latitude"].max().compute().item(),
+        cdm_lite_dataset["longitude"].min().compute().item(),
+        cdm_lite_dataset["longitude"].max().compute().item(),
     )
     time_start = "{:%Y%m%d}".format(
         cdm_lite_dataset.report_timestamp[0].compute().dt.date


### PR DESCRIPTION
if latitude|observations_table and longitude|observations_table are present, we keep rename those and remove the others. If not, we rename the others (can either be header_table or station_configuration).

We do not take into account the case of both header_table and station_configuration coordinates to be present. I'm not sure this is possible, I need to check this.