### PR TITLE
Make cryptography mandatory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,11 @@ classifiers = [
 ]
 dependencies = [
   # Only mandatory dependencies required by the broker and retrieve-api images
+  "cryptography",
   "DateTimeRange",
   "python-dateutil",
   "structlog",
-  "jsonschema"
+  "jsonschema",
 ]
 description = "CADS data retrieve utilities to be used by adaptors"
 dynamic = ["version"]
@@ -36,7 +37,6 @@ complete = [
   "cdsapi",
   "cfgrib>=0.9.14.0",
   "cftime",
-  "cryptography",
   "dask",
   "ecmwflibs",
   "earthkit-transforms>=0.3.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "DateTimeRange",
   "python-dateutil",
   "structlog",
-  "jsonschema",
+  "jsonschema"
 ]
 description = "CADS data retrieve utilities to be used by adaptors"
 dynamic = ["version"]


### PR DESCRIPTION
We should make cryptography a mandatory dependencies. CI did not fail because it was installed by the packages we use to build in the distribution job (wheel/build/pip). As it's a simple and widely used library, I think it's OK to make it mandatory (no need to refactor the code)