### PR TITLE
Use request_id instead of request_uid

### DIFF
--- a/cads_adaptors/adaptors/cams_regional_fc/cams_regional_fc.py
+++ b/cads_adaptors/adaptors/cams_regional_fc/cams_regional_fc.py
@@ -317,7 +317,7 @@ def retrieve_subrequest(backend, requests, req_group, config, context):
             dataset,
             {"requests": requests, "parent_config": config},
         )
-        sub_request_uid = response.request_uid
+        sub_request_uid = response.request_id
         context.info(
             f"Sub-request {sub_request_uid} has been launched (via the " "CDSAPI)."
         )

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
 - h5netcdf
 - jinja2
 - jsonschema
-- multiurl=0.3.1
+- multiurl>=0.3.3
 - netcdf4
 - numpy
 - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ channels:
 # DO NOT EDIT ABOVE THIS LINE, ADD DEPENDENCIES BELOW AS SHOWN IN THE EXAMPLE
 dependencies:
 - aiohttp
-- cdsapi
+- cdsapi>=0.7.6
 - cfgrib>=0.9.14.0
 - cftime
 - cryptography

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ complete = [
   "fsspec",
   "h5netcdf",
   "jinja2",
-  "multiurl==0.3.1",
+  "multiurl>=0.3.3",
   "netcdf4",
   "numpy",
   "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ complete = [
   "boto3",
   "cacholote",
   "cads-mars-server@git+https://github.com/ecmwf-projects/cads-mars-server.git",
-  "cdsapi",
+  "cdsapi>=0.7.6",
   "cfgrib>=0.9.14.0",
   "cftime",
   "dask",


### PR DESCRIPTION
Currently, both `response.request_id` and `response.request_uid` work, but in the future only `response.request_id` will work.