### PR TITLE
Cds 421 multi adaptor intersect constraints

### DIFF
--- a/tests/test_15_adaptor_multi.py
+++ b/tests/test_15_adaptor_multi.py
@@ -252,7 +252,7 @@ def test_multi_adaptor_split_adaptors():
 
     # Check that the sub-adaptors have the correct values
     for adaptor in ["mean", "max"]:
-        sub_adaptor_request = sub_adaptors[adaptor][1]
+        sub_adaptor_request = sub_adaptors[f"{adaptor}-0"][1]
         assert sub_adaptor_request == ADAPTOR_CONFIG["adaptors"][adaptor]["values"]
 
     for adaptor_tag, [adaptor, req] in sub_adaptors.items():
@@ -273,8 +273,8 @@ def test_multi_adaptor_split_adaptors_required_keys():
         request,
     )
 
-    assert "mean" not in sub_adaptors.keys()
-    assert "max" in sub_adaptors.keys()
+    assert "mean-0" not in sub_adaptors.keys()
+    assert "max-0" in sub_adaptors.keys()
 
 
 def test_multi_adaptor_split_adaptors_dont_split_keys():
@@ -288,9 +288,9 @@ def test_multi_adaptor_split_adaptors_dont_split_keys():
         request,
     )
 
-    assert "dont_split" in sub_adaptors["mean"][1].keys()
-    assert "dont_split" not in sub_adaptors["max"][1].keys()
-    assert "area" in sub_adaptors["max"][1].keys()
+    assert "dont_split" in sub_adaptors["mean-0"][1].keys()
+    assert "dont_split" not in sub_adaptors["max-0"][1].keys()
+    assert "area" in sub_adaptors["max-0"][1].keys()
 
 
 def test_convert_format(tmp_path, monkeypatch):

--- a/tests/test_30_area_selector.py
+++ b/tests/test_30_area_selector.py
@@ -176,7 +176,7 @@ def test_area_selector_regular(ds, area, test_result):
     result = area_selector(ds, area=area)
 
     assert isinstance(result, xr.Dataset)
-    assert result.dims == test_result.dims
+    assert result.sizes == test_result.sizes
     assert np.allclose(result.latitude.values, test_result.latitude.values)
     assert np.allclose(result.longitude.values, test_result.longitude.values)
 
@@ -219,7 +219,7 @@ def test_area_selector_path_regular(ds, area, test_result):
         result = area_selector_path(test_file, area=area)
         result_xr = xr.open_dataset(result[0])
         assert isinstance(result_xr, xr.Dataset)
-        assert result_xr.dims == test_result.dims
+        assert result_xr.sizes == test_result.sizes
         assert np.allclose(result_xr.latitude.values, test_result.latitude.values)
         assert np.allclose(result_xr.longitude.values, test_result.longitude.values)
 


### PR DESCRIPTION
https://jira.ecmwf.int/browse/CDS-421

The approach taken will intersect the constraints at the top level, then submit complete hypercube requests to the sub-adaptors. This may mean that we create a large number of sub-requests, but I think that is fine and safer than trying to merge them back into a single dictionary.

I also addressed some deprecation warnings in the tests, Dataset.dims -> Dataset.sizes