### PR TITLE
safely handle kwargs in convertors.py

### DIFF
--- a/cads_adaptors/tools/convertors.py
+++ b/cads_adaptors/tools/convertors.py
@@ -1,6 +1,7 @@
 import itertools
 import os
 import time
+from copy import deepcopy
 from typing import Any, Callable, NoReturn
 
 import cfgrib
@@ -47,10 +48,14 @@ def convert_format(
     result: Any,
     target_format: str,
     context: Context = Context(),
-    config: dict[str, Any] = {},
+    config: None | dict[str, Any] = None,
     target_dir: str = ".",
     **runtime_kwargs: dict[str, dict[str, Any]],
 ) -> list[str]:
+    config = deepcopy(config)
+    if config is None:
+        config = {}
+
     target_format = adaptor_tools.handle_data_format(target_format)
     post_processing_kwargs = config.get("post_processing_kwargs", {})
     for k, v in runtime_kwargs.items():
@@ -176,7 +181,7 @@ def result_to_netcdf_files(
 def result_to_netcdf_legacy_files(
     result: Any,
     context: Context = Context(),
-    to_netcdf_legacy_kwargs: dict[str, Any] = {},
+    to_netcdf_legacy_kwargs: None | dict[str, Any] = None,
     target_dir: str = ".",
     **kwargs,
 ) -> list[str]:
@@ -185,6 +190,10 @@ def result_to_netcdf_legacy_files(
     Can only accept a grib file, or list/dict of grib files as input.
     Converts to netCDF3 only.
     """
+    to_netcdf_legacy_kwargs = deepcopy(to_netcdf_legacy_kwargs)
+    if to_netcdf_legacy_kwargs is None:
+        to_netcdf_legacy_kwargs = {}
+
     command: str | list[str] = to_netcdf_legacy_kwargs.get(
         "command", ["grib_to_netcdf", "-S", "param"]
     )
@@ -316,7 +325,7 @@ def unknown_filetype_to_netcdf_files(
 def grib_to_netcdf_files(
     grib_file: str,
     open_datasets_kwargs: None | dict[str, Any] | list[dict[str, Any]] = None,
-    post_open_datasets_kwargs: dict[str, Any] = {},
+    post_open_datasets_kwargs: None | dict[str, Any] = None,
     context: Context = Context(),
     **kwargs,
 ):
@@ -352,7 +361,7 @@ def xarray_dict_to_netcdf(
     datasets: dict[str, xr.Dataset],
     context: Context = Context(),
     compression_options: str | dict[str, Any] = "default",
-    to_netcdf_kwargs: dict[str, Any] = {},
+    to_netcdf_kwargs: None | dict[str, Any] = None,
     out_fname_prefix: str = "",
     target_dir: str = ".",
     **kwargs,
@@ -361,6 +370,9 @@ def xarray_dict_to_netcdf(
     Convert a dictionary of xarray datasets to netCDF files, where the key of the dictionary
     is used in the filename.
     """
+    to_netcdf_kwargs = deepcopy(to_netcdf_kwargs)
+    if to_netcdf_kwargs is None:
+        to_netcdf_kwargs = {}
     # Untangle any nested kwargs (I don't think this is necessary anymore)
     to_netcdf_kwargs.update(kwargs.pop("to_netcdf_kwargs", {}))
 
@@ -507,13 +519,17 @@ def safely_expand_dims(dataset: xr.Dataset, expand_dims: list[str]) -> xr.Datase
 
 def post_open_datasets_modifications(
     datasets: dict[str, xr.Dataset],
-    rename: dict[str, str] = {},
-    expand_dims: list[str] = [],
+    rename: None | dict[str, str] = None,
+    expand_dims: None | list[str] = None,
 ) -> dict[str, Any]:
     """
     Apply post-opening modifications to the datasets, such as renaming variables
     and expanding dimensions.
     """
+    if rename is None:
+        rename = {}
+    if expand_dims is None:
+        expand_dims = []
     out_datasets = {}
     for out_fname_base, dataset in datasets.items():
         dataset = safely_rename_variable(dataset, rename)
@@ -529,14 +545,20 @@ def post_open_datasets_modifications(
 def open_netcdf_as_xarray_dictionary(
     netcdf_file: str,
     context: Context = Context(),
-    open_datasets_kwargs: list[dict[str, Any]] | dict[str, Any] = {},
-    post_open_datasets_kwargs: dict[str, Any] = {},
+    open_datasets_kwargs: None | list[dict[str, Any]] | dict[str, Any] = None,
+    post_open_datasets_kwargs: None | dict[str, Any] = None,
     **kwargs,
 ) -> dict[str, xr.Dataset]:
     """
     Open a netcdf file and return as a dictionary of xarray datasets,
     where the key will be used in any filenames created from the dataset.
     """
+    open_datasets_kwargs = deepcopy(open_datasets_kwargs)
+    if open_datasets_kwargs is None:
+        open_datasets_kwargs = {}
+    post_open_datasets_kwargs = deepcopy(post_open_datasets_kwargs)
+    if post_open_datasets_kwargs is None:
+        post_open_datasets_kwargs = {}
     fname, _ = os.path.splitext(os.path.basename(netcdf_file))
 
     if isinstance(open_datasets_kwargs, list):
@@ -656,7 +678,7 @@ def prepare_open_datasets_kwargs_grib(
 def open_grib_file_as_xarray_dictionary(
     grib_file: str,
     open_datasets_kwargs: None | dict[str, Any] | list[dict[str, Any]] = None,
-    post_open_datasets_kwargs: dict[str, Any] = {},
+    post_open_datasets_kwargs: None | dict[str, Any] = None,
     context: Context = Context(),
     **kwargs,
 ) -> dict[str, xr.Dataset]:
@@ -665,8 +687,13 @@ def open_grib_file_as_xarray_dictionary(
     where the key will be used in any filenames created from the dataset.
     """
     fname, _ = os.path.splitext(os.path.basename(grib_file))
+    open_datasets_kwargs = deepcopy(open_datasets_kwargs)
     if open_datasets_kwargs is None:
         open_datasets_kwargs = {}
+
+    post_open_datasets_kwargs = deepcopy(post_open_datasets_kwargs)
+    if post_open_datasets_kwargs is None:
+        post_open_datasets_kwargs = {}
 
     # Do any automatic splitting of the open_datasets_kwargs,
     #  This will add kwargs to the open_datasets_kwargs


### PR DESCRIPTION
This is to handle the case of mystery kwarg leaking:

1. Default kwarg dictionaries and lists as None
2. deepcopy to be safe