### PR TITLE
Retry resume connection errors only

### DIFF
--- a/cads_adaptors/exceptions.py
+++ b/cads_adaptors/exceptions.py
@@ -34,7 +34,15 @@ class MarsSystemError(SystemError):
 
 
 class UrlNoDataError(InvalidRequest):
-    """Raised when a MARS request returns no data."""
+    """Raised when an URL request returns no data."""
+
+
+class UrlConnectionError(InvalidRequest):
+    """Raised when an URL request suffers a connection error."""
+
+
+class UrlUnknownError(InvalidRequest):
+    """Raised when an URL request suffers an error of unknown origin."""
 
 
 class MultiAdaptorNoDataError(InvalidRequest):

--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -141,7 +141,7 @@ def try_download(
                     "issue with the data source, please try your request again. "
                     "If the issue persists, please contact user support."
                 )
-                raise UrlUnknownError(e)
+                raise e  #UrlUnknownError(e)
         else:
             paths.append(path)
 

--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Generator, List, Optional
 import jinja2
 import multiurl
 import requests
+import re
 import yaml
 from tqdm import tqdm
 
@@ -108,6 +109,10 @@ def try_download(
             # To remove this, we would need to change how we use jinja in gecko and here,
             # or have a check against the URLs in the manifest file.
             status = e.response.status_code if e.response else None
+            # Sometimes the status code is not in the exception, but can be found in message:
+            if status is None:
+                match = re.match(r"(\d{3})", str(e))
+                status = int(match.group(1)) if match else None
             context.debug(f"HTTP error {status} for URL {url}, skipping download.")
             if not (status and status >= 400 and status < 500):
                 # If the error is not a 4XX, we raise it as an exception

--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import re
 import tarfile
 import time
 import urllib
@@ -9,7 +10,6 @@ from typing import Any, Dict, Generator, List, Optional
 import jinja2
 import multiurl
 import requests
-import re
 import yaml
 from tqdm import tqdm
 
@@ -138,7 +138,7 @@ def try_download(
             )
         except Exception as e:
             context.error(f"Failed download for URL: {url}\nException: {e}")
-            # System flag to raise unknown exceptions, this is a change in 
+            # System flag to raise unknown exceptions, this is a change in
             # behaviour hence to be monitored when changed.
             # Setting to True is closer to how the legacy CDS operated.
             if os.getenv("RAISE_UKNOWN_URL_EXCEPTIONS", False):

--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -108,6 +108,7 @@ def try_download(
             # To remove this, we would need to change how we use jinja in gecko and here,
             # or have a check against the URLs in the manifest file.
             status = e.response.status_code if e.response else None
+            context.debug(f"HTTP error {status} for URL {url}, skipping download.")
             if not (status and status >= 400 and status < 500):
                 # If the error is not a 4XX, we raise it as an exception
                 context.error(f"Failed download for URL: {url}\nException: {e}")
@@ -116,7 +117,7 @@ def try_download(
                     "issue with the data source, please try your request again. "
                     "If the issue persists, please contact user support."
                 )
-                raise UrlUnknownError(e)
+                raise e
             context.debug(f"HTTP error {status} for URL {url}, skipping download.")
         except UrlConnectionError:
             # The way "multiurl" uses "requests" at the moment,

--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -122,7 +122,7 @@ def try_download(
                     "issue with the data source, please try your request again. "
                     "If the issue persists, please contact user support."
                 )
-                raise e
+                raise UrlUnknownError(e)
             context.debug(f"HTTP error {status} for URL {url}, skipping download.")
         except UrlConnectionError:
             # The way "multiurl" uses "requests" at the moment,
@@ -147,7 +147,7 @@ def try_download(
                     "issue with the data source, please try your request again. "
                     "If the issue persists, please contact user support."
                 )
-                raise e  #UrlUnknownError(e)
+                raise UrlUnknownError(e)
         else:
             paths.append(path)
 

--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -77,7 +77,10 @@ def try_download(
                         **kwargs,
                     )
                     break
-                except Exception as e:
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.ReadTimeout,
+                ) as e:
                     downloaded_bytes = os.path.getsize(path)
                     context.add_stdout(
                         f"Attempt {i_retry+1} to download {url} failed "
@@ -91,7 +94,10 @@ def try_download(
                     )
                     if i_retry + 1 == max_retries:
                         raise
-        except requests.exceptions.ConnectionError as e:
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ReadTimeout,
+        ) as e:
             # The way "multiurl" uses "requests" at the moment,
             # the read timeouts raise requests.exceptions.ConnectionError.
             if kwargs.get("fail_on_timeout_for_any_part", True):


### PR DESCRIPTION
This is to fix the multiple retries to URLs that do not exist, and we know they do not exist.
The URL adaptor, and config generation relies on ignoring 404s and 403s, see comment added to the code below.

```
  # We don't care about HTTP 4XX errors, the current adaptor setup relies on ignoring them
  # The reason for this is that our jinja templating is an incomplete extension of jinja,
  # which uses patterns created from multiple regex definitions.
  # It is possible that a single valid combination of key:values pairs can create multiple URLs,
  # but only one should exist.
  # To remove this, we would need to change how we use jinja in gecko and here,
  # or have a check against the URLs in the manifest file.
```