### PR TITLE
Use the new disabled fields endpoint to exclude fields from the observations adaptor output

### DIFF
--- a/cads_adaptors/adaptors/cadsobs/adaptor.py
+++ b/cads_adaptors/adaptors/cadsobs/adaptor.py
@@ -49,14 +49,17 @@ class ObservationsAdaptor(AbstractCdsAdaptor):
         # dataset_source must be a string, asking for two sources is unsupported
         dataset_source = self.handle_sources_list(self.mapped_request["dataset_source"])
         self.mapped_request["dataset_source"] = dataset_source
-
-        self.mapped_request = self.adapt_parameters()
         # Get CDM lite variables as a dict with mandatory, optional and auxiliary
         cadsobs_client = CadsobsApiClient(obs_api_url, self.context)
         cdm_lite_variables_dict = cadsobs_client.get_cdm_lite_variables()
         cdm_lite_variables = (
             cdm_lite_variables_dict["mandatory"] + cdm_lite_variables_dict["optional"]
         )
+        # Remove the disabled fields
+        disabled_fields = cadsobs_client.get_disabled_fields(
+            dataset_name, dataset_source
+        )
+        cdm_lite_variables = [v for v in cdm_lite_variables if v not in disabled_fields]
         # Get the objects that match the request
         object_urls = cadsobs_client.get_objects_to_retrieve(
             dataset_name, self.mapped_request

--- a/cads_adaptors/adaptors/cadsobs/api_client.py
+++ b/cads_adaptors/adaptors/cadsobs/api_client.py
@@ -123,7 +123,7 @@ class CadsobsApiClient:
         """Get the list of fields that are disabled for the given dataset."""
         try:
             response = self._send_request_and_capture_exceptions(
-                "GET", f"/{dataset_name}/{dataset_source}/disabled_variables"
+                "GET", f"/{dataset_name}/{dataset_source}/disabled_fields"
             )
         except CadsObsConnectionError as e:
             self.context.warning(

--- a/cads_adaptors/adaptors/cadsobs/api_client.py
+++ b/cads_adaptors/adaptors/cadsobs/api_client.py
@@ -107,7 +107,7 @@ class CadsobsApiClient:
             )
         except CadsObsConnectionError as e:
             self.context.warning(
-                f"Requess failed for payload {payload}: {e}, possibly the API it "
+                f"Request failed for payload {payload}: {e}, possibly the API it "
                 f"outdated, falling back to the old payload format."
             )
             payload = dict(
@@ -127,7 +127,7 @@ class CadsobsApiClient:
             )
         except CadsObsConnectionError as e:
             self.context.warning(
-                f"Requess failed when getting the list of disabled fields"
+                f"Request failed when getting the list of disabled fields"
                 f"for {dataset_name=} and {dataset_source=}: {e}, "
                 f"possibly the API it outdated"
             )

--- a/cads_adaptors/adaptors/cadsobs/api_client.py
+++ b/cads_adaptors/adaptors/cadsobs/api_client.py
@@ -107,8 +107,8 @@ class CadsobsApiClient:
             )
         except CadsObsConnectionError as e:
             self.context.warning(
-                f"Requess failed: {e}, possibly the API it outdated, "
-                f"falling back to the old payload format."
+                f"Requess failed for payload {payload}: {e}, possibly the API it "
+                f"outdated, falling back to the old payload format."
             )
             payload = dict(
                 retrieve_args=dict(dataset=dataset_name, params=mapped_request),
@@ -118,3 +118,18 @@ class CadsobsApiClient:
                 "POST", "get_object_urls_and_check_size", payload=payload
             )
         return objects_to_retrieve
+
+    def get_disabled_fields(self, dataset_name: str, dataset_source: str) -> list[str]:
+        """Get the list of fields that are disabled for the given dataset."""
+        try:
+            response = self._send_request_and_capture_exceptions(
+                "GET", f"/{dataset_name}/{dataset_source}/disabled_variables"
+            )
+        except CadsObsConnectionError as e:
+            self.context.warning(
+                f"Requess failed when getting the list of disabled fields"
+                f"for {dataset_name=} and {dataset_source=}: {e}, "
+                f"possibly the API it outdated"
+            )
+            response = []
+        return response


### PR DESCRIPTION
* It is backwards compatible so it will work with older versions of the API, where the new endpoint is not available.
* The fields to be excluded are defined in the cdsobs_config.yml used by the observations API. Right now it is only used to exclude fields for insitu-comprehensive-upper-air-observation-network.
* We decided to use a new endpoint for this as this way we can use it for other datasets too, instead of hardcoding this for CUON only somewhere.