### PR TITLE
Fix for os.makedirs on Atos in cams_regional_fc

### DIFF
--- a/cads_adaptors/adaptors/cams_regional_fc/cacher.py
+++ b/cads_adaptors/adaptors/cams_regional_fc/cacher.py
@@ -276,8 +276,9 @@ class AbstractAsyncCacher(AbstractCacher):
             except BaseException as e:
                 self._fatal_exception = self._fatal_exception or e
                 if self._fatal_exception is e:
-                    self.logger.error("self._wait_for_threads raised "
-                                      f"{type(e).__name__}: {e}")
+                    self.logger.error(
+                        "self._wait_for_threads raised " f"{type(e).__name__}: {e}"
+                    )
 
         if self._fatal_exception:
             e = self._fatal_exception
@@ -297,8 +298,9 @@ class AbstractAsyncCacher(AbstractCacher):
                 )
             except Exception as e:
                 self._fatal_exception = self._fatal_exception or e
-                self.logger.error(f"Thread {ithread} raised "
-                                  f"{type(e).__name__}: {e}")
+                self.logger.error(
+                    f"Thread {ithread} raised {type(e).__name__}: {e}"
+                )
                 # This won't cancel running futures, but it's better than
                 # nothing
                 [f.cancel() for f in self._futures]
@@ -320,9 +322,11 @@ class AbstractAsyncCacher(AbstractCacher):
         """Asynchronously cache fields."""
         # Refuse puts if the object is in an error state
         if self._fatal_exception:
-            raise Exception("Cacher has raised "
-                            f"{type(self._fatal_exception).__name__}: "
-                            f"{self._fatal_exception}")
+            raise Exception(
+                "Cacher has raised "
+                f"{type(self._fatal_exception).__name__}: "
+                f"{self._fatal_exception}"
+            )
         # Start the copying thread if not done already
         with self._locks[0]:
             if not self._futures:
@@ -339,8 +343,7 @@ class AbstractAsyncCacher(AbstractCacher):
             # Signal to other threads that they should stop because this one
             # encountered an exception
             self._fatal_exception = self._fatal_exception or e
-            self.logger.error(f"{type(e).__name__} exception in copy thread: "
-                              f"{e}")
+            self.logger.error(f"{type(e).__name__} exception in copy thread: {e}")
             raise
 
     def _copier2(self, ithread):
@@ -410,7 +413,8 @@ class AbstractAsyncCacher(AbstractCacher):
         writable. The hypothesis is that this is due to multiple simultaneous
         os.makedirs calls combined with a makedirs bug that possibly only
         manifests on Lustre. Wrapping the calls in a lock is an attempt to
-        prevent it happening again."""
+        prevent it happening again.
+        """
         # The use of self._dirs_made is just to reduce how often the lock is
         # held and os.makedirs is called. It's possibly over-optimisation.
         if args[0] not in self._dirs_made:

--- a/cads_adaptors/adaptors/cams_regional_fc/cacher.py
+++ b/cads_adaptors/adaptors/cams_regional_fc/cacher.py
@@ -277,7 +277,7 @@ class AbstractAsyncCacher(AbstractCacher):
                 self._fatal_exception = self._fatal_exception or e
                 if self._fatal_exception is e:
                     self.logger.error(
-                        "self._wait_for_threads raised " f"{type(e).__name__}: {e}"
+                        f"self._wait_for_threads raised {type(e).__name__}: {e}"
                     )
 
         if self._fatal_exception:

--- a/cads_adaptors/adaptors/cams_regional_fc/cacher.py
+++ b/cads_adaptors/adaptors/cams_regional_fc/cacher.py
@@ -409,8 +409,8 @@ class AbstractAsyncCacher(AbstractCacher):
         """There have been a couple of incidents (Jun 14 and Jul 14 2025) where
         a directory has ended up with the wrong permissions and so not been
         writable. The hypothesis is that this is due to multiple simultaneous
-        os.makedirs calls combined with a makedirs bug that possibly only
-        manifests on Lustre. Wrapping the calls in a lock is an attempt to
+        os.makedirs calls combined with a makedirs race condition that possibly
+        only manifests on Lustre. Wrapping the calls in a lock is an attempt to
         prevent it happening again.
         """
         # The use of self._dirs_made is just to reduce how often the lock is

--- a/cads_adaptors/adaptors/cams_regional_fc/cacher.py
+++ b/cads_adaptors/adaptors/cams_regional_fc/cacher.py
@@ -281,9 +281,9 @@ class AbstractAsyncCacher(AbstractCacher):
                     )
 
         if self._fatal_exception:
-            e = self._fatal_exception
-            self.logger.error(f"Cacher failed with {type(e).__name__}: {e}")
-            raise e
+            ex = self._fatal_exception
+            self.logger.error(f"Cacher failed with {type(ex).__name__}: {ex}")
+            raise ex
 
     def _wait_for_threads(self):
         close_time = time.time()

--- a/cads_adaptors/adaptors/cams_regional_fc/cacher.py
+++ b/cads_adaptors/adaptors/cams_regional_fc/cacher.py
@@ -401,7 +401,7 @@ class AbstractAsyncCacher(AbstractCacher):
         os.makedirs calls combined with a makedirs bug that possibly only
         manifests on Lustre. Wrapping the calls in a lock is an attempt to
         prevent it happening again."""
-        with self.locks[2]:
+        with self._locks[2]:
             os.makedirs(*args, **kwargs)
 
 

--- a/cads_adaptors/adaptors/cams_regional_fc/cacher.py
+++ b/cads_adaptors/adaptors/cams_regional_fc/cacher.py
@@ -298,9 +298,7 @@ class AbstractAsyncCacher(AbstractCacher):
                 )
             except Exception as e:
                 self._fatal_exception = self._fatal_exception or e
-                self.logger.error(
-                    f"Thread {ithread} raised {type(e).__name__}: {e}"
-                )
+                self.logger.error(f"Thread {ithread} raised {type(e).__name__}: {e}")
                 # This won't cancel running futures, but it's better than
                 # nothing
                 [f.cancel() for f in self._futures]


### PR DESCRIPTION
The cams_regional_fc adaptor contains some multi-threaded code that runs on the Atos when updating the dataset. It writes files to a Lustre filesystem but it appears that os.makedirs has a race condition on Lustre that can very occasionally result in directories with the wrong permissions. This update wraps the os.makedirs in a threading lock to avoid that.

It also slightly tidies up exception handling in the multi-threaded code.