### PR TITLE
Restrict the cases when we retry a download to ConnectionError and ReadTimeout

### DIFF
--- a/cads_adaptors/tools/url_tools.py
+++ b/cads_adaptors/tools/url_tools.py
@@ -77,7 +77,10 @@ def try_download(
                         **kwargs,
                     )
                     break
-                except Exception as e:
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.ReadTimeout,
+                ) as e:
                     downloaded_bytes = os.path.getsize(path)
                     context.add_stdout(
                         f"Attempt {i_retry+1} to download {url} failed "


### PR DESCRIPTION
This is the essential part of the more involved effort to avoid 404 checks and related matters.